### PR TITLE
Add support for an InstallSnapshot RPC in Raft nodes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,5 @@ rust:
 cache: cargo
 install:
   - ./tools/install_proto.sh
+env:
+  - RUST_BACKTRACE=1

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,7 +18,7 @@ use std::time::Duration;
 
 use keyvalue_proto::Operation;
 use protobuf::Message;
-use raft::{Client, Diagnostics, RaftImpl};
+use raft::{Client, Config, Diagnostics, RaftImpl};
 use raft_proto::{EntryId, Server};
 use raft_proto_grpc::RaftServer;
 
@@ -51,7 +51,13 @@ fn start_node(address: &Server, all: &Vec<Server>, diagnostics: &mut Diagnostics
 
     let state_machine = Box::new(keyvalue::MapStore::new());
     let mut server_builder = grpc::ServerBuilder::new_plain();
-    let raft = RaftImpl::new(address, all, state_machine, Some(server_diagnostics));
+    let raft = RaftImpl::new(
+        address,
+        all,
+        state_machine,
+        Some(server_diagnostics),
+        Config::default(),
+    );
     raft.start();
 
     server_builder.add_service(RaftServer::new_service_def(raft));

--- a/src/raft/consensus.rs
+++ b/src/raft/consensus.rs
@@ -53,7 +53,7 @@ pub struct Config {
 }
 
 impl Config {
-    fn default() -> Self {
+    pub fn default() -> Self {
         Config {
             follower_timeout_ms: DEFAULT_FOLLOWER_TIMEOUTS_MS,
             candidate_timeouts_ms: DEFAULT_CANDIDATE_TIMEOUT_MS,
@@ -75,16 +75,17 @@ impl RaftImpl {
         all: &Vec<Server>,
         state_machine: Box<dyn StateMachine + Send>,
         diagnostics: Option<Arc<Mutex<ServerDiagnostics>>>,
+        config: Config,
     ) -> RaftImpl {
         RaftImpl {
             address: server.clone(),
             state: Arc::new(Mutex::new(RaftState {
-                config: Config::default(),
+                config,
 
                 term: 0,
                 voted_for: None,
                 log: LogSlice::initial(),
-                state_machine: state_machine,
+                state_machine,
 
                 committed: -1,
                 applied: -1,

--- a/src/raft/consensus.rs
+++ b/src/raft/consensus.rs
@@ -777,6 +777,9 @@ impl Raft for RaftImpl {
             }
         }
 
+        // TODO(dino): Need to make sure that after installing a snaphot, the
+        // leader's request to append the next entry succeeds.
+
         let mut result = InstallSnapshotResponse::new();
         result.set_term(state.term);
         return sink.finish(result);

--- a/src/raft/consensus.rs
+++ b/src/raft/consensus.rs
@@ -968,7 +968,7 @@ mod tests {
         let mut server_builder = grpc::ServerBuilder::new_plain();
         raft.start();
         server_builder.add_service(RaftServer::new_service_def(raft));
-        server_builder.http.set_port(0);
+        server_builder.http.set_addr(("::1", 0)).unwrap();
         server_builder.build().expect("server")
     }
 

--- a/src/raft/consensus.rs
+++ b/src/raft/consensus.rs
@@ -812,9 +812,6 @@ impl Raft for RaftImpl {
             }
         }
 
-        // TODO(dino): Need to make sure that after installing a snaphot, the
-        // leader's request to append the next entry succeeds.
-
         let mut result = InstallSnapshotResponse::new();
         result.set_term(state.term);
         return sink.finish(result);
@@ -853,6 +850,9 @@ mod tests {
         assert_eq!(state.applied, -1);
     }
 
+    // This test verifies that initially, a follower fails to accept entries
+    // too far in the future. Then, after installing an appropriate snapshot,
+    // sending those same entries succeeds.
     #[test]
     fn test_load_snapshot_and_append() {
         let raft = create_raft();

--- a/src/raft/consensus.rs
+++ b/src/raft/consensus.rs
@@ -28,9 +28,7 @@ use timer::Timer;
 use bytes::{Buf, Bytes};
 use diagnostics::ServerDiagnostics;
 use raft::log::{ContainsResult, LogSlice};
-use raft_proto::{
-    AppendRequest, AppendResponse, Entry, EntryId, Server, VoteRequest, VoteResponse,
-};
+use raft_proto::{AppendRequest, AppendResponse, EntryId, Server, VoteRequest, VoteResponse};
 use raft_proto::{CommitRequest, CommitResponse, Status, StepDownRequest, StepDownResponse};
 use raft_proto::{InstallSnapshotRequest, InstallSnapshotResponse};
 use raft_proto_grpc::{Raft, RaftClient};
@@ -837,6 +835,7 @@ fn entry_id_key(entry_id: &EntryId) -> String {
 mod tests {
     use super::*;
     use crate::raft::StateMachineResult;
+    use crate::raft_proto::Entry;
     use futures::executor;
     use raft_proto_grpc::RaftServer;
 

--- a/src/raft/consensus.rs
+++ b/src/raft/consensus.rs
@@ -968,14 +968,14 @@ mod tests {
         let mut server_builder = grpc::ServerBuilder::new_plain();
         raft.start();
         server_builder.add_service(RaftServer::new_service_def(raft));
-        server_builder.http.set_addr(("::1", 0)).unwrap();
+        server_builder.http.set_addr(("0.0.0.0", 0)).unwrap();
         server_builder.build().expect("server")
     }
 
     fn create_grpc_client(server: &grpc::Server) -> RaftClient {
         let client_conf = Default::default();
         let port = server.local_addr().port().expect("port");
-        RaftClient::new_plain("::1", port, client_conf).expect("client")
+        RaftClient::new_plain("0.0.0.0", port, client_conf).expect("client")
     }
 
     struct FakeStateMachine {

--- a/src/raft/log.rs
+++ b/src/raft/log.rs
@@ -192,8 +192,15 @@ impl LogSlice {
     // log index. Must only be called if the index is known to be within range
     // of this slice.
     fn local_index(&self, index: i64) -> usize {
-        let adjusted = index - self.previous_id.get_index() - 1;
-        assert!(adjusted >= 0, "adjusted index out of range");
+        let previous = self.previous_id.get_index();
+        let adjusted = index - previous - 1;
+        assert!(
+            adjusted >= 0,
+            "adjusted index out of range: adjusted={}, index={}, previous={}",
+            adjusted,
+            index,
+            previous
+        );
         adjusted as usize
     }
 }

--- a/src/raft/mod.rs
+++ b/src/raft/mod.rs
@@ -20,7 +20,7 @@ mod client;
 pub use client::Client;
 
 mod consensus;
-pub use consensus::RaftImpl;
+pub use consensus::{Config, RaftImpl};
 
 mod diagnostics;
 pub use diagnostics::Diagnostics;

--- a/src/raft/raft_proto.proto
+++ b/src/raft/raft_proto.proto
@@ -83,7 +83,7 @@ enum Status {
 }
 
 // Request to add a new entry to the shared raft log. Only the leader can
-// process these request. Followers will return a NOT_LEADER error.
+// process these requests. Followers will return a NOT_LEADER error.
 message CommitRequest {
   // The payload to append to the log.
   bytes payload = 1;
@@ -117,10 +117,34 @@ message StepDownResponse {
   Server leader = 2;
 }
 
+// Sent by the leader of the cluster to its peers in order to transmit a
+// snapshot of the underlying state machine to the follower.
+message InstallSnapshotRequest {
+  // Term of the rpc originator.
+  int64 term = 1;
+
+  // Current leader. Always the originator of the rpc.
+  Server leader = 2;
+
+  // The id of the latest entry included in the snapshot. The snapshot replaces
+  // all entries up to (and including) this one on the receiver.
+  EntryId last = 3;
+
+  // The snapshot bytes, as obtained from the state machine.
+  // TODO(dino): send chunks instead of entire snapshots.
+  bytes snapshot = 4;
+}
+
+message InstallSnapshotResponse {
+  // Term of the rpc recipient.
+  int64 term = 1;
+}
+
 service Raft {
   rpc Vote (VoteRequest) returns (VoteResponse) {}
   rpc Append (AppendRequest) returns (AppendResponse) {}
   rpc Commit (CommitRequest) returns (CommitResponse) {}
   rpc StepDown (StepDownRequest) returns (StepDownResponse) {}
+  rpc InstallSnapshot (InstallSnapshotRequest) returns (InstallSnapshotResponse) {}
 }
 


### PR DESCRIPTION
This RPC allows the leader to install a snapshot on a follower in case the follower falls behind (or is catching up from scratch after joining a cluster). The RPC is not yet called, but we have a new integration test which executes the flow and behaves as expected.