### PR TITLE
Add support for notifying listeners when the committed index advances

### DIFF
--- a/src/keyvalue/store.rs
+++ b/src/keyvalue/store.rs
@@ -15,13 +15,13 @@ use keyvalue_proto::{Entry, Operation, Snapshot};
 
 #[derive(Debug, Clone)]
 pub struct StoreError {
-    message: String,
+    _message: String,
 }
 
 impl StoreError {
     fn new(message: &str) -> Self {
         StoreError {
-            message: String::from(message),
+            _message: String::from(message),
         }
     }
 }

--- a/src/raft/consensus.rs
+++ b/src/raft/consensus.rs
@@ -704,7 +704,9 @@ impl RaftState {
         {
             let next = self.listeners.pop_first().expect("get first");
             if !self.log.is_index_compacted(next.index) {
-                next.sender.send(self.log.id_at(next.index));
+                next.sender
+                    .send(self.log.id_at(next.index))
+                    .expect("receiver dropped early!");
             } else {
                 // Do nothing, we just let the sender go out of scope, which will notify the
                 // receiver of the cancellation


### PR DESCRIPTION
This allows us to rewrite the implementation of the "commit()" RPC body without any polling.