### PR TITLE
Replace the main commit loop with a loop that puts values into the keyvalue service

### DIFF
--- a/src/keyvalue/mod.rs
+++ b/src/keyvalue/mod.rs
@@ -5,12 +5,12 @@
 pub use service::KeyValueService;
 
 pub mod grpc {
-    pub use crate::keyvalue::keyvalue_proto::{GetRequest, GetResponse, PutRequest, PutResponse};
     pub use crate::keyvalue::keyvalue_proto::key_value_client::KeyValueClient;
     pub use crate::keyvalue::keyvalue_proto::key_value_server::KeyValueServer;
+    pub use crate::keyvalue::keyvalue_proto::{GetRequest, GetResponse, PutRequest, PutResponse};
 }
 
 #[path = "generated/keyvalue_proto.rs"]
-pub (in crate::keyvalue) mod keyvalue_proto;
-pub (in crate::keyvalue) mod service;
-pub (in crate::keyvalue) mod store;
+pub(in crate::keyvalue) mod keyvalue_proto;
+pub(in crate::keyvalue) mod service;
+pub(in crate::keyvalue) mod store;

--- a/src/keyvalue/service.rs
+++ b/src/keyvalue/service.rs
@@ -5,14 +5,14 @@ use prost::Message;
 use tonic::{Request, Response, Status};
 
 use crate::keyvalue::keyvalue_proto;
+use crate::keyvalue::keyvalue_proto::key_value_server::KeyValue;
+use crate::keyvalue::keyvalue_proto::operation::Op;
 use crate::keyvalue::keyvalue_proto::{
     Entry, GetRequest, GetResponse, Operation, PutRequest, PutResponse, SetOperation,
 };
-use crate::keyvalue::keyvalue_proto::key_value_server::KeyValue;
-use crate::keyvalue::keyvalue_proto::operation::Op;
 use crate::keyvalue::store::{MapStore, Store};
-use crate::raft::{Client, new_client, StateMachine};
 use crate::raft::raft_proto::Server;
+use crate::raft::{new_client, Client, StateMachine};
 
 // This allows us to combine two non-auto traits into one.
 trait StoreStateMachine: Store + StateMachine {}

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,6 +38,7 @@ async fn run_server(address: &Server, all: &Vec<Server>, diagnostics: Arc<Mutex<
     // A service used to serve the keyvalue store, backed by the
     // underlying Raft cluster.
     let keyvalue = KeyValueService::new(&address);
+    info!("Created keyvalue service for {:?}", &address);
 
     // A service used by the Raft cluster.
     let server_diagnostics = diagnostics.lock().await.get_server(&address);
@@ -50,6 +51,7 @@ async fn run_server(address: &Server, all: &Vec<Server>, diagnostics: Arc<Mutex<
         Config::default(),
     );
     raft.start().await;
+    info!("Created raft service for {:?}", &address);
 
     let serve = tonic::transport::Server::builder()
         .add_service(RaftServer::new(raft))

--- a/src/raft/client.rs
+++ b/src/raft/client.rs
@@ -4,8 +4,8 @@ use async_std::sync::Mutex;
 use async_trait::async_trait;
 use log::debug;
 use tokio::time::sleep;
-use tonic::Request;
 use tonic::transport::{Channel, Error};
+use tonic::Request;
 
 use raft_proto::{CommitRequest, EntryId, Server, Status, StepDownRequest};
 

--- a/src/raft/consensus.rs
+++ b/src/raft/consensus.rs
@@ -17,8 +17,8 @@ use log::{debug, error, info, warn};
 use rand::Rng;
 use tokio::task::JoinHandle;
 use tokio::time::sleep;
-use tonic::{Request, Response, Status};
 use tonic::transport::{Channel, Endpoint, Error};
+use tonic::{Request, Response, Status};
 
 use diagnostics::ServerDiagnostics;
 use raft::log::{ContainsResult, LogSlice};

--- a/src/raft/mod.rs
+++ b/src/raft/mod.rs
@@ -8,7 +8,7 @@
 // The implementation in this module is based on the paper at:
 // https://raft.github.io/raft.pdf
 
-pub use client::{Client, new_client};
+pub use client::{new_client, Client};
 pub use consensus::{Config, RaftImpl};
 pub use diagnostics::Diagnostics;
 pub use state_machine::{StateMachine, StateMachineResult};
@@ -16,8 +16,8 @@ pub use state_machine::{StateMachine, StateMachineResult};
 #[path = "generated/raft_proto.rs"]
 pub mod raft_proto;
 
-mod log;
 mod client;
 mod consensus;
 mod diagnostics;
+mod log;
 mod state_machine;


### PR DESCRIPTION
Now `main.rs` no longer pokes into the internal details of the Raft cluster. Instead, it commits values by interacting with the keyvalue service, which in turn commits values to the underlying Raft cluster.

This also allows us to clean up a whole bunch of leaky exports.