### PR TITLE
Split storage-related functionality into a separate Store concept

### DIFF
--- a/src/raft/consensus.rs
+++ b/src/raft/consensus.rs
@@ -976,7 +976,7 @@ fn address_key(address: &Server) -> String {
 #[cfg(test)]
 mod tests {
     use crate::raft::raft_proto::raft_server::RaftServer;
-    use crate::raft::StateMachineResult;
+    use crate::raft::testing::FakeStateMachine;
     use crate::raft_proto::Entry;
     use crate::testing::TestServer;
 
@@ -988,8 +988,6 @@ mod tests {
         let state = raft.state.lock().await;
         assert_eq!(state.role, RaftRole::Follower);
         assert_eq!(state.term, 0);
-        assert_eq!(state.store.committed, -1);
-        assert_eq!(state.store.applied, -1);
     }
 
     // This test verifies that initially, a follower fails to accept entries
@@ -1199,33 +1197,5 @@ mod tests {
         RaftClient::connect(format!("http://[::1]:{}", port))
             .await
             .expect("client")
-    }
-
-    struct FakeStateMachine {
-        committed: i64,
-        snapshots_loaded: i64,
-    }
-
-    impl FakeStateMachine {
-        fn new() -> Self {
-            FakeStateMachine {
-                committed: 0,
-                snapshots_loaded: 0,
-            }
-        }
-    }
-
-    impl StateMachine for FakeStateMachine {
-        fn apply(&mut self, _operation: &Bytes) -> StateMachineResult {
-            self.committed += 1;
-            Ok(())
-        }
-        fn create_snapshot(&self) -> Bytes {
-            Bytes::from(Vec::new())
-        }
-        fn load_snapshot(&mut self, _snapshot: &Bytes) -> StateMachineResult {
-            self.snapshots_loaded += 1;
-            Ok(())
-        }
     }
 }

--- a/src/raft/consensus.rs
+++ b/src/raft/consensus.rs
@@ -28,7 +28,7 @@ use raft_proto::{InstallSnapshotRequest, InstallSnapshotResponse};
 
 use crate::raft;
 use crate::raft::diagnostics;
-use crate::raft::store::{CommitListener, LogSnapshot, Store};
+use crate::raft::store::{LogSnapshot, Store};
 use crate::raft_proto::raft_client::RaftClient;
 use crate::raft_proto::raft_server::Raft;
 

--- a/src/raft/consensus.rs
+++ b/src/raft/consensus.rs
@@ -550,7 +550,7 @@ impl RaftState {
             leader: Some(self.address.clone()),
             previous: Some(previous.clone()),
             entries: self.store.log.get_entries_after(&previous),
-            committed: self.store.committed,
+            committed: self.store.committed_index(),
         }
     }
 

--- a/src/raft/consensus.rs
+++ b/src/raft/consensus.rs
@@ -91,13 +91,7 @@ impl RaftImpl {
 
                 term: 0,
                 voted_for: None,
-                store: Store {
-                    log: LogSlice::initial(),
-                    state_machine,
-                    snapshot: None,
-                    listener_uid: 0,
-                    listeners: BTreeSet::new(),
-                },
+                store: Store::new(state_machine),
 
                 committed: -1,
                 applied: -1,

--- a/src/raft/mod.rs
+++ b/src/raft/mod.rs
@@ -22,3 +22,6 @@ mod diagnostics;
 mod log;
 mod state_machine;
 mod store;
+
+#[cfg(test)]
+mod testing;

--- a/src/raft/mod.rs
+++ b/src/raft/mod.rs
@@ -21,3 +21,4 @@ mod consensus;
 mod diagnostics;
 mod log;
 mod state_machine;
+mod store;

--- a/src/raft/store.rs
+++ b/src/raft/store.rs
@@ -3,7 +3,7 @@ use crate::raft::raft_proto::EntryId;
 use crate::raft::StateMachine;
 use async_std::sync::{Arc, Mutex};
 use bytes::Bytes;
-use futures::channel::oneshot::{channel, Receiver, Sender};
+use futures::channel::oneshot::Sender;
 use std::cmp::Ordering;
 use std::collections::BTreeSet;
 
@@ -19,6 +19,8 @@ pub struct Store {
     pub snapshot: Option<LogSnapshot>,
     pub listener_uid: i64,
     pub listeners: BTreeSet<CommitListener>,
+    pub committed: i64,
+    pub applied: i64,
 }
 
 impl Store {
@@ -29,6 +31,8 @@ impl Store {
             snapshot: None,
             listener_uid: 0,
             listeners: BTreeSet::new(),
+            committed: -1,
+            applied: -1,
         }
     }
 }

--- a/src/raft/store.rs
+++ b/src/raft/store.rs
@@ -18,7 +18,7 @@ use tonic::Status;
 pub struct Store {
     pub log: LogSlice,
     state_machine: Arc<Mutex<dyn StateMachine + Send>>,
-    pub snapshot: Option<LogSnapshot>,
+    snapshot: Option<LogSnapshot>,
 
     listener_uid: i64,
     listeners: BTreeSet<CommitListener>,

--- a/src/raft/store.rs
+++ b/src/raft/store.rs
@@ -21,6 +21,18 @@ pub struct Store {
     pub listeners: BTreeSet<CommitListener>,
 }
 
+impl Store {
+    pub fn new(state_machine: Arc<Mutex<dyn StateMachine + Send>>) -> Self {
+        Self {
+            log: LogSlice::initial(),
+            state_machine,
+            snapshot: None,
+            listener_uid: 0,
+            listeners: BTreeSet::new(),
+        }
+    }
+}
+
 // Represents a snapshot of the state machine after applying a complete prefix
 // of entries since the beginning of time.
 pub struct LogSnapshot {

--- a/src/raft/store.rs
+++ b/src/raft/store.rs
@@ -23,7 +23,7 @@ pub struct Store {
     listener_uid: i64,
     listeners: BTreeSet<CommitListener>,
 
-    pub committed: i64,
+    committed: i64,
     applied: i64,
 
     compaction_threshold_bytes: i64,
@@ -47,6 +47,12 @@ impl Store {
             compaction_threshold_bytes,
             name: name.to_string(),
         }
+    }
+
+    // Returns the index up to (and including) which the corresponding entries are
+    // considered committed.
+    pub fn committed_index(&self) -> i64 {
+        self.committed
     }
 
     // Compacts logs entries into a new snapshot if necessary.

--- a/src/raft/store.rs
+++ b/src/raft/store.rs
@@ -184,3 +184,23 @@ impl Ord for CommitListener {
 fn entry_id_key(entry_id: &EntryId) -> String {
     format!("(term={},id={})", entry_id.term, entry_id.index)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::raft::testing::FakeStateMachine;
+
+    const COMPACTION_THRESHOLD_BYTES: i64 = 5000;
+
+    #[test]
+    fn test_initial() {
+        let store = Store::new(
+            Arc::new(Mutex::new(FakeStateMachine::new())),
+            COMPACTION_THRESHOLD_BYTES,
+            "testing-store",
+        );
+
+        assert_eq!(store.committed, -1);
+        assert_eq!(store.applied, -1);
+    }
+}

--- a/src/raft/store.rs
+++ b/src/raft/store.rs
@@ -1,3 +1,11 @@
+use crate::raft::log::LogSlice;
+use crate::raft::raft_proto::EntryId;
+use crate::raft::StateMachine;
+use async_std::sync::{Arc, Mutex};
+use bytes::Bytes;
+use futures::channel::oneshot::{channel, Receiver, Sender};
+use std::cmp::Ordering;
+use std::collections::BTreeSet;
 
 // Handles persistent storage for a Raft member, including a snapshot starting
 // from the beginning of time up to some index, and running log of entries since
@@ -5,6 +13,54 @@
 //
 // Also takes care of periodic compaction, updating listeners when the committed
 // portion reaches as certain index, etc.
-struct Store {
-    
+pub struct Store {
+    pub log: LogSlice,
+    pub state_machine: Arc<Mutex<dyn StateMachine + Send>>,
+    pub snapshot: Option<LogSnapshot>,
+    pub listener_uid: i64,
+    pub listeners: BTreeSet<CommitListener>,
+}
+
+// Represents a snapshot of the state machine after applying a complete prefix
+// of entries since the beginning of time.
+pub struct LogSnapshot {
+    // The id of the latest entry included in the snapshot.
+    pub last: EntryId,
+
+    // The snapshot bytes as produced by the state machine.
+    pub snapshot: Bytes,
+}
+
+// Each instance represents an ongoing commit operation waiting for the committed
+// index to reach the index of their tentative new entry.
+#[derive(Debug)]
+pub struct CommitListener {
+    // The index the listener would like to be notified about.
+    pub index: i64,
+
+    // Used to send the resulting entry id to the listener.
+    pub sender: Sender<EntryId>,
+
+    // Used to disambiguate between structs for the same index.
+    pub uid: i64,
+}
+
+impl Eq for CommitListener {}
+
+impl PartialEq<Self> for CommitListener {
+    fn eq(&self, other: &Self) -> bool {
+        (self.index, self.uid).eq(&(other.index, other.uid))
+    }
+}
+
+impl PartialOrd<Self> for CommitListener {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        (self.index, self.uid).partial_cmp(&(other.index, other.uid))
+    }
+}
+
+impl Ord for CommitListener {
+    fn cmp(&self, other: &Self) -> Ordering {
+        (self.index, self.uid).cmp(&(other.index, other.uid))
+    }
 }

--- a/src/raft/store.rs
+++ b/src/raft/store.rs
@@ -1,0 +1,10 @@
+
+// Handles persistent storage for a Raft member, including a snapshot starting
+// from the beginning of time up to some index, and running log of entries since
+// the index included in the last snapshot.
+//
+// Also takes care of periodic compaction, updating listeners when the committed
+// portion reaches as certain index, etc.
+struct Store {
+    
+}

--- a/src/raft/store.rs
+++ b/src/raft/store.rs
@@ -82,6 +82,11 @@ impl Store {
     // Marks the stored entries up to (and including) the supplied index as committed,
     // informing any listeners if necessary, applying changes to the state machine, etc.
     pub async fn commit_to(&mut self, new_commit_index: i64) {
+        if new_commit_index <= self.committed {
+            // Nothing to do here, already committed past the supplied index.
+            return;
+        }
+
         // This has a built-in assertion that the entry is present in the log.
         self.log.id_at(new_commit_index);
 

--- a/src/raft/store.rs
+++ b/src/raft/store.rs
@@ -19,7 +19,7 @@ pub struct Store {
     pub state_machine: Arc<Mutex<dyn StateMachine + Send>>,
     pub snapshot: Option<LogSnapshot>,
     pub listener_uid: i64,
-    pub listeners: BTreeSet<CommitListener>,
+    listeners: BTreeSet<CommitListener>,
     pub committed: i64,
     pub applied: i64,
 
@@ -148,15 +148,15 @@ pub struct LogSnapshot {
 // Each instance represents an ongoing commit operation waiting for the committed
 // index to reach the index of their tentative new entry.
 #[derive(Debug)]
-pub struct CommitListener {
+struct CommitListener {
     // The index the listener would like to be notified about.
-    pub index: i64,
+    index: i64,
 
     // Used to send the resulting entry id to the listener.
-    pub sender: Sender<EntryId>,
+    sender: Sender<EntryId>,
 
     // Used to disambiguate between structs for the same index.
-    pub uid: i64,
+    uid: i64,
 }
 
 impl Eq for CommitListener {}

--- a/src/raft/store.rs
+++ b/src/raft/store.rs
@@ -18,8 +18,10 @@ pub struct Store {
     pub log: LogSlice,
     pub state_machine: Arc<Mutex<dyn StateMachine + Send>>,
     pub snapshot: Option<LogSnapshot>,
-    pub listener_uid: i64,
+
+    listener_uid: i64,
     listeners: BTreeSet<CommitListener>,
+
     pub committed: i64,
     pub applied: i64,
 

--- a/src/raft/testing.rs
+++ b/src/raft/testing.rs
@@ -1,0 +1,34 @@
+use crate::raft::{StateMachine, StateMachineResult};
+use bytes::Bytes;
+
+// A fake implementation of the StateMachine trait for testing
+// purposes.
+pub struct FakeStateMachine {
+    committed: i64,
+    snapshots_loaded: i64,
+}
+
+impl FakeStateMachine {
+    pub fn new() -> Self {
+        FakeStateMachine {
+            committed: 0,
+            snapshots_loaded: 0,
+        }
+    }
+}
+
+impl StateMachine for FakeStateMachine {
+    fn apply(&mut self, _operation: &Bytes) -> StateMachineResult {
+        self.committed += 1;
+        Ok(())
+    }
+
+    fn create_snapshot(&self) -> Bytes {
+        Bytes::from(Vec::new())
+    }
+
+    fn load_snapshot(&mut self, _snapshot: &Bytes) -> StateMachineResult {
+        self.snapshots_loaded += 1;
+        Ok(())
+    }
+}


### PR DESCRIPTION
The consensus.rs module was getting out of hand in terms of size and complexity. This change splits some of that logic out into a "Store" module which can be tested and reasoned about in isolation.