### PR TITLE
Add support for updating cluster membership

### DIFF
--- a/src/keyvalue/service.rs
+++ b/src/keyvalue/service.rs
@@ -164,6 +164,10 @@ mod tests {
         async fn preempt_leader(&self) -> Result<Server, Status> {
             unimplemented!();
         }
+
+        async fn change_config(&self, _members: Vec<Server>) -> Result<(), Status> {
+            unimplemented!();
+        }
     }
 
     #[tokio::test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -111,6 +111,8 @@ async fn run_preempt_loop(args: Arc<Arguments>, all: &Vec<Server>) {
     let name = "main-preempt";
     let client = raft::new_client(name, &member);
     loop {
+        sleep(Duration::from_secs(4)).await;
+
         let start = Instant::now();
         match client.preempt_leader().await {
             Ok(leader) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -163,6 +163,8 @@ async fn run_reconfigure(args: Arc<Arguments>, old: Vec<Server>, new: Vec<Server
         return;
     }
 
+    sleep(Duration::from_secs(10)).await;
+
     info!(?old, ?new, "reconfiguring");
     // TODO(dino): Have old and new actually be different.
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -163,7 +163,7 @@ async fn run_reconfigure(args: Arc<Arguments>, old: Vec<Server>, new: Vec<Server
         return;
     }
 
-    sleep(Duration::from_secs(10)).await;
+    sleep(Duration::from_secs(5)).await;
 
     info!(?old, ?new, "reconfiguring");
     // TODO(dino): Have old and new actually be different.

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,7 @@ use futures::future::join_all;
 use rand::seq::SliceRandom;
 use structopt::StructOpt;
 use tokio::time::{sleep, Instant};
-use tracing::{debug, error, info, info_span, Instrument};
+use tracing::{error, info, info_span, Instrument};
 use tracing_subscriber::EnvFilter;
 
 use raft::raft_proto;
@@ -102,6 +102,7 @@ async fn run_server(address: &Server, all: &Vec<Server>, diagnostics: Arc<Mutex<
 // cluster to recover by electing a new one.
 async fn run_preempt_loop(args: Arc<Arguments>, all: &Vec<Server>) {
     if args.disable_preempt {
+        info!("running without the preempt loop");
         return;
     }
 
@@ -126,6 +127,7 @@ async fn run_preempt_loop(args: Arc<Arguments>, all: &Vec<Server>) {
 // raft implementation.
 async fn run_validate_loop(args: Arc<Arguments>, diag: Arc<Mutex<Diagnostics>>) {
     if args.disable_validate {
+        info!("running without the validate loop");
         return;
     }
 
@@ -142,6 +144,7 @@ async fn run_validate_loop(args: Arc<Arguments>, diag: Arc<Mutex<Diagnostics>>) 
 // Repeatedly picks a random server in the cluster and sends a put request.
 async fn run_put_loop(args: Arc<Arguments>, all: &Vec<Server>) {
     if args.disable_commit {
+        info!("running without the put loop");
         return;
     }
 
@@ -167,12 +170,13 @@ async fn run_put_loop(args: Arc<Arguments>, all: &Vec<Server>) {
 
 async fn run_reconfigure_loop(args: Arc<Arguments>, all: &Vec<Server>) {
     if args.disable_reconfigure {
+        info!("running without the reconfigure loop");
         return;
     }
 
     let first = all.first().unwrap().clone();
     loop {
-        sleep(Duration::from_secs(10)).await;
+        sleep(Duration::from_secs(15)).await;
 
         // The new members are the first entry (always) and 2 out of the 4 others.
         let mut new = vec![first.clone()];

--- a/src/raft/client.rs
+++ b/src/raft/client.rs
@@ -173,17 +173,15 @@ impl Client for ClientImpl {
     // Adds the supplied payload as the next entry in the cluster's shared log.
     // Returns once the payload has been added (or the operation has failed).
     async fn commit(&self, payload: &[u8]) -> Result<EntryId, tonic::Status> {
-        self.retry_helper(async move |leader: Server| {
-            ClientImpl::commit_impl(leader, payload).await
-        })
-        .await
+        let op = async move |leader: Server| ClientImpl::commit_impl(leader, payload).await;
+        self.retry_helper(op).await
     }
 
     // Sends an rpc to the cluster leader to step down. Returns the address of
     // the leader which stepped down.
     async fn preempt_leader(&self) -> Result<Server, tonic::Status> {
-        self.retry_helper(async move |leader: Server| ClientImpl::preempt_leader_impl(leader).await)
-            .await
+        let op = async move |leader: Server| ClientImpl::preempt_leader_impl(leader).await;
+        self.retry_helper(op).await
     }
 }
 

--- a/src/raft/cluster.rs
+++ b/src/raft/cluster.rs
@@ -1,7 +1,7 @@
 use crate::raft::raft_proto::raft_client::RaftClient;
 use crate::raft::raft_proto::{ClusterConfig, Server};
-use std::time::Duration;
 use std::collections::{HashMap, HashSet};
+use std::time::Duration;
 use tonic::transport::{Channel, Endpoint, Error};
 
 // Holds information about a Raft cluster.
@@ -125,7 +125,6 @@ impl Cluster {
     }
 
     pub fn create_joint(&self, new_members: Vec<Server>) -> ClusterConfig {
-
         // TODO - DONOTLAND
         // This doesn't actually work because we need quorum among both the old
         // members and the new members, which is different from quorum among the

--- a/src/raft/cluster.rs
+++ b/src/raft/cluster.rs
@@ -1,4 +1,4 @@
-use crate::raft::raft_proto::entry::Data::{Config, Payload};
+use crate::raft::raft_proto::entry::Data::Config;
 use crate::raft::raft_proto::raft_client::RaftClient;
 use crate::raft::raft_proto::{ClusterConfig, Server};
 use crate::raft::store::ConfigInfo;
@@ -105,18 +105,6 @@ impl Cluster {
 
     // Updates the cluster's members based on the supplied latest cluster information.
     pub fn update(&mut self, info: ConfigInfo) {
-        if let Some(entry) = &info.latest {
-            match &entry.data {
-                // TODO(dino): Why is this never happening?!
-                Some(Config(inner)) => {
-                    info!(name=%inner.name, ">>>> updating cluster with config info");
-                }
-                _ => {
-                    panic!("bad payload");
-                }
-            }
-        }
-
         if let Some(inner) = &self.config_info {
             if inner == &info {
                 // Nothing to do.
@@ -134,7 +122,7 @@ impl Cluster {
             },
         }
 
-        info!("updating cluster config");
+        info!(committed=info.committed, config_name=%config.name, "updating cluster config");
 
         self.config_info = Some(info.clone());
         if info.committed {

--- a/src/raft/cluster.rs
+++ b/src/raft/cluster.rs
@@ -104,11 +104,12 @@ impl Cluster {
     }
 
     // Updates the cluster's members based on the supplied latest cluster information.
-    pub fn update(&mut self, info: ConfigInfo) {
+    // Returns whether an update took place.
+    pub fn update(&mut self, info: ConfigInfo) -> bool {
         if let Some(inner) = &self.config_info {
             if inner == &info {
                 // Nothing to do.
-                return;
+                return false;
             }
         }
 
@@ -116,13 +117,13 @@ impl Cluster {
         let config;
         let index;
         match &info.latest {
-            None => return,
+            None => return false,
             Some(entry) => match &entry.data {
                 Some(Config(c)) => {
                     index = entry.id.as_ref().expect("id").index;
                     config = c.clone();
                 }
-                _ => return,
+                _ => return false,
             },
         }
 
@@ -140,6 +141,7 @@ impl Cluster {
         self.channels.drain();
 
         info!(committed = info.committed, index, "new cluster config");
+        true
     }
 
     // Returns an rpc client which can be used to contact the supplied peer.

--- a/src/raft/cluster.rs
+++ b/src/raft/cluster.rs
@@ -114,15 +114,17 @@ impl Cluster {
 
         // Only keep going if there's an actual config inside.
         let config;
+        let index;
         match &info.latest {
             None => return,
             Some(entry) => match &entry.data {
-                Some(Config(c)) => config = c.clone(),
+                Some(Config(c)) => {
+                    index = entry.id.as_ref().expect("id").index;
+                    config = c.clone();
+                }
                 _ => return,
             },
         }
-
-        info!(committed=info.committed, config_name=%config.name, "updating cluster config");
 
         self.config_info = Some(info.clone());
         if info.committed {
@@ -136,6 +138,8 @@ impl Cluster {
         }
         // We could probably reuse some of these. Clear them all for now.
         self.channels.drain();
+
+        info!(committed = info.committed, index, "new cluster config");
     }
 
     // Returns an rpc client which can be used to contact the supplied peer.
@@ -170,7 +174,6 @@ impl Cluster {
         ClusterConfig {
             voters: self.voters.values().cloned().collect(),
             voters_next: new_voters,
-            name: "asdf".to_string(), // TODO(dino) fix/remove name
         }
     }
 

--- a/src/raft/cluster.rs
+++ b/src/raft/cluster.rs
@@ -125,6 +125,14 @@ impl Cluster {
     }
 
     pub fn create_joint(&self, new_members: Vec<Server>) -> ClusterConfig {
+
+        // TODO - DONOTLAND
+        // This doesn't actually work because we need quorum among both the old
+        // members and the new members, which is different from quorum among the
+        // union. We probably want a special "joint" mode and to have the
+        // consensus module ask the cluster whether there is sufficient quorum
+        // based on a set of votes from different servers.
+
         let mut keys = HashSet::<String>::new();
         let mut union = Vec::<Server>::new();
 

--- a/src/raft/cluster.rs
+++ b/src/raft/cluster.rs
@@ -178,10 +178,9 @@ impl Cluster {
         }
     }
 
-    // Returns all known members of the cluster.
+    // Returns all voting members of the cluster.
     fn all(&self) -> HashMap<String, Server> {
         let mut result = HashMap::new();
-        result.insert(key(&self.me), self.me.clone());
         result.extend(self.voters.clone());
         result.extend(self.voters_next.clone());
         result
@@ -247,6 +246,22 @@ mod tests {
         let s2 = server("bar", 1234, "name1");
         let s3 = server("baz", 1234, "name1");
         Cluster::new(s2.clone(), vec![s1, s2, s3].as_slice())
+    }
+
+    #[test]
+    fn test_all() {
+        let s1 = server("foo", 1234, "name1");
+        let s2 = server("bar", 1234, "name1");
+        let s3 = server("baz", 1234, "name1");
+        let cluster = Cluster::new(
+            s2.clone(),
+            vec![s1.clone(), s2.clone(), s3.clone()].as_slice(),
+        );
+
+        assert!(cluster.all().contains_key(key(&s1).as_str()));
+        assert!(cluster.all().contains_key(key(&s2).as_str()));
+        assert!(cluster.all().contains_key(key(&s3).as_str()));
+        assert_eq!(cluster.all().len(), 3);
     }
 
     #[test]

--- a/src/raft/cluster.rs
+++ b/src/raft/cluster.rs
@@ -59,11 +59,6 @@ impl Cluster {
         all.into_values().collect()
     }
 
-    // Returns the number of participants in the cluster (including us).
-    pub fn size(&self) -> usize {
-        self.others().len() + 1
-    }
-
     // Returns whether there is an ongoing cluster configuration transition.
     pub fn has_ongoing_mutation(&self) -> bool {
         !self.voters_next.is_empty()
@@ -257,7 +252,7 @@ mod tests {
     #[test]
     fn test_initial() {
         let cluster = create_cluster();
-        assert_eq!(cluster.size(), 3);
+        assert_eq!(cluster.voters.len(), 3);
         assert_eq!(cluster.others().len(), 2);
         assert!(cluster.leader().is_none());
     }
@@ -281,7 +276,6 @@ mod tests {
     fn test_singleton_cluster() {
         let me = server("foo", 1234, "some-name");
         let cluster = Cluster::new(me.clone(), vec![me.clone()].as_slice());
-        assert_eq!(cluster.size(), 1);
         assert!(cluster.others().is_empty());
     }
 
@@ -305,13 +299,13 @@ mod tests {
             .as_slice(),
         );
 
-        assert_eq!(cluster.size(), 3);
+        assert_eq!(cluster.voters.len(), 3);
     }
 
     #[test]
     fn test_quorum() {
         let cluster = create_cluster();
-        assert_eq!(cluster.size(), 3);
+        assert_eq!(cluster.voters.len(), 3);
 
         // No votes other than ourself, no quorum.
         assert!(!cluster.is_quorum(&Vec::new()));

--- a/src/raft/cluster.rs
+++ b/src/raft/cluster.rs
@@ -247,6 +247,7 @@ mod tests {
                 server("wiggle", 1234, "name"),
                 server("ziggle", 1234, "name"),
             ],
+            members_next: vec![],
         };
         cluster.update(new_config);
         assert_eq!(cluster.size(), 5);

--- a/src/raft/consensus.rs
+++ b/src/raft/consensus.rs
@@ -428,12 +428,6 @@ impl RaftImpl {
                 return Err(raft_proto::Status::NotLeader);
             }
 
-            let mut is_config = false;
-            if let Config(inner) = &data {
-                info!(name=%inner.name, ">>>> commit_internal with config change");
-                is_config;
-            }
-
             term = state.term;
             entry_id = state.store.append(term, data);
             receiver = state.store.add_listener(entry_id.index);
@@ -905,7 +899,7 @@ impl Raft for RaftImpl {
         request: Request<ChangeConfigRequest>,
     ) -> Result<Response<ChangeConfigResponse>, Status> {
         let request = request.into_inner();
-        info!(?request, "handling request");
+        debug!(?request, "handling request");
 
         let joint_config;
         {
@@ -927,7 +921,7 @@ impl Raft for RaftImpl {
         let joint = joint_config.clone();
         let result = RaftImpl::commit_internal(self.state.clone(), Config(joint_config)).await;
 
-        info!(?joint, "committed config");
+        debug!(?joint, "committed config");
 
         let leader = self.state.lock().await.cluster.leader().clone();
         let status = match result {

--- a/src/raft/consensus.rs
+++ b/src/raft/consensus.rs
@@ -783,6 +783,9 @@ impl Raft for RaftImpl {
             state.store.log.append_all(request.entries.as_slice());
         }
 
+        // TODO(dino): scan the appended entries for the latest one with a cluster
+        // config change and update the membership info.
+
         // If the leader considers an entry committed, it is guaranteed that
         // all members of the cluster agree on the log up to that index, so it
         // is safe to apply the entries to the state machine.
@@ -880,6 +883,7 @@ fn address_key(address: &Server) -> String {
 
 #[cfg(test)]
 mod tests {
+    use crate::raft::raft_proto::entry::Data;
     use crate::raft::raft_proto::raft_server::RaftServer;
     use crate::raft::testing::FakeStateMachine;
     use crate::raft_proto::Entry;
@@ -1060,7 +1064,7 @@ mod tests {
     fn entry(id: EntryId, payload: Vec<u8>) -> Entry {
         Entry {
             id: Some(id),
-            payload,
+            data: Some(Data::Payload(payload)),
         }
     }
 

--- a/src/raft/consensus.rs
+++ b/src/raft/consensus.rs
@@ -794,6 +794,7 @@ impl Raft for RaftImpl {
                         "Udpated cluster config based on entry: [term={}, index={}]",
                         id.term, id.index
                     );
+                    break;
                 }
             }
         }

--- a/src/raft/consensus.rs
+++ b/src/raft/consensus.rs
@@ -804,7 +804,7 @@ impl Raft for RaftImpl {
 
         // Store all the entries received.
         if !request.entries.is_empty() {
-            state.store.log.append_all(request.entries.as_slice());
+            state.store.append_all(request.entries.as_slice());
         }
 
         // If the leader considers an entry committed, it is guaranteed that

--- a/src/raft/consensus.rs
+++ b/src/raft/consensus.rs
@@ -1,7 +1,7 @@
 extern crate rand;
 
-use std::fmt::{Display, Formatter};
 use std::collections::{HashMap, HashSet};
+use std::fmt::{Display, Formatter};
 use std::future::Future;
 use std::pin::Pin;
 use std::time::Duration;

--- a/src/raft/consensus.rs
+++ b/src/raft/consensus.rs
@@ -163,7 +163,7 @@ impl RaftImpl {
             }
 
             if !state.cluster.am_voting_member() {
-                info!("no longer voting member, not running election");
+                info!("not voting member, aborted election");
                 return true;
             }
 
@@ -705,7 +705,7 @@ impl RaftState {
         self.cluster.update(config_info);
 
         if self.role == Leader && !self.cluster.am_voting_member() {
-            info!("leader no longer voting member, stepping down");
+            info!(role=?self.role, "not voting member, stepping down");
             let term = self.term;
             self.become_follower(arc_state, term);
         }

--- a/src/raft/consensus.rs
+++ b/src/raft/consensus.rs
@@ -901,19 +901,7 @@ impl Raft for RaftImpl {
 
             // TODO
             // 1) Create joint configuration
-
-            let union: HashSet<Server> = state
-                .cluster
-                .others()
-                .iter()
-                .cloned()
-                .chain(state.cluster.me().into())
-                .chain(request.members.iter().cloned())
-                .collect();
-            let joint = ClusterConfig {
-                members: union.into_iter().collect(),
-                members_next: request.members,
-            };
+            let joint_config = state.cluster.create_joint(request.members.to_vec());
 
             // 2) Commit joint configuration
             // 3) Return success

--- a/src/raft/consensus.rs
+++ b/src/raft/consensus.rs
@@ -207,6 +207,10 @@ impl RaftImpl {
             }
 
             let mut votes = Vec::new();
+
+            // We always vote for ourself.
+            votes.push(state.cluster.me());
+
             for response in results {
                 match response {
                     Ok((peer, message)) => {

--- a/src/raft/log.rs
+++ b/src/raft/log.rs
@@ -126,7 +126,7 @@ impl LogSlice {
         if self.entries.is_empty() {
             return None;
         }
-        for i in self.entries.len() - 1..0 {
+        for i in (0..self.entries.len()).rev() {
             let entry = self.entries.get(i).unwrap();
             if matches!(&entry.data, Some(Config(_))) {
                 return Some(entry.clone());

--- a/src/raft/raft_proto.proto
+++ b/src/raft/raft_proto.proto
@@ -18,10 +18,10 @@ message Server {
 // Configuration for the cluster.
 message ClusterConfig {
   // Determines which members are considered part of the cluster.
-  repeated Server members = 1;
+  repeated Server voters = 1;
 
   // Holds the next set of members for the cluster.
-  repeated Server members_next = 2;
+  repeated Server voters_next = 2;
 }
 
 // Identifies an entry in a given log.

--- a/src/raft/raft_proto.proto
+++ b/src/raft/raft_proto.proto
@@ -93,6 +93,9 @@ message AppendResponse {
 
   // Indicates whether or not the entries were appended successfully.
   bool success = 2;
+
+  // The current "next" index in the recipient's log.
+  int64 next = 3;
 }
 
 // Status of a requested operation.

--- a/src/raft/raft_proto.proto
+++ b/src/raft/raft_proto.proto
@@ -22,6 +22,9 @@ message ClusterConfig {
 
   // Holds the next set of members for the cluster.
   repeated Server voters_next = 2;
+
+  // A name for the config, used only for debugging.
+  string name = 3;
 }
 
 // Identifies an entry in a given log.

--- a/src/raft/raft_proto.proto
+++ b/src/raft/raft_proto.proto
@@ -22,9 +22,6 @@ message ClusterConfig {
 
   // Holds the next set of members for the cluster.
   repeated Server voters_next = 2;
-
-  // A name for the config, used only for debugging.
-  string name = 3;
 }
 
 // Identifies an entry in a given log.

--- a/src/raft/raft_proto.proto
+++ b/src/raft/raft_proto.proto
@@ -19,6 +19,9 @@ message Server {
 message ClusterConfig {
   // Determines which members are considered part of the cluster.
   repeated Server members = 1;
+
+  // Holds the next set of members for the cluster.
+  repeated Server members_next = 2;
 }
 
 // Identifies an entry in a given log.
@@ -160,11 +163,32 @@ message InstallSnapshotResponse {
   int64 term = 1;
 }
 
+// A request to change the cluster's configuration. The actual transition
+// happens as a two-step process where the first step is to commit an
+// intermediate "joint consensus" configuration. This request returns once
+// that intermediate configuration has been committed (which guarantees that
+// the new config requested in this change will be applied eventually).
+message ChangeConfigRequest {
+  // The new desired (voting) members of the cluster.
+  repeated Server members = 1;
+}
+
+// A response for configuration changes.
+message ChangeConfigResponse {
+  // Indicates whether the configuration has been changed successfully.
+  Status status = 1;
+
+  // The last known leader of the raft cluster. Not populated if the cluster
+  // has never had a leader.
+  Server leader = 2;
+}
+
 service Raft {
   rpc Vote (VoteRequest) returns (VoteResponse) {}
   rpc Append (AppendRequest) returns (AppendResponse) {}
   rpc Commit (CommitRequest) returns (CommitResponse) {}
   rpc StepDown (StepDownRequest) returns (StepDownResponse) {}
   rpc InstallSnapshot (InstallSnapshotRequest) returns (InstallSnapshotResponse) {}
+  rpc ChangeConfig (ChangeConfigRequest) returns (ChangeConfigResponse) {}
 }
 

--- a/src/raft/raft_proto.proto
+++ b/src/raft/raft_proto.proto
@@ -15,6 +15,12 @@ message Server {
   string name = 3;
 }
 
+// Configuration for the cluster.
+message ClusterConfig {
+  // Determines which members are considered part of the cluster.
+  repeated Server members = 1;
+}
+
 // Identifies an entry in a given log.
 message EntryId {
   int64 term = 1;
@@ -24,7 +30,15 @@ message EntryId {
 // Represents an entry in a server's log.
 message Entry {
   EntryId id = 1;
-  bytes payload = 2;
+
+  oneof data {
+    // An opaque payload which can be applied to the state machine.
+    bytes payload = 2;
+
+    // An updated configuration for the cluster. Used to effect membership
+    // changes and similar reconfigurations.
+    ClusterConfig config = 3;
+  }
 }
 
 // Sent by candidate to request votes from its peers. If a quorum of votes is

--- a/src/raft/store.rs
+++ b/src/raft/store.rs
@@ -292,7 +292,7 @@ mod tests {
     #[should_panic]
     async fn test_commit_to_bad_index() {
         let mut store = make_store();
-        store.log.append(2, Payload(Vec::new()));
+        store.append(2, Payload(Vec::new()));
 
         // Attempt to "commit to" a value which hasn't yet been appended.
         store.commit_to(17).await;
@@ -301,7 +301,7 @@ mod tests {
     #[tokio::test]
     async fn test_commit_to() {
         let mut store = make_store();
-        let eid = store.log.append(2, Payload(Vec::new()));
+        let eid = store.append(2, Payload(Vec::new()));
 
         // Should succeed.
         store.commit_to(eid.index).await;
@@ -315,9 +315,9 @@ mod tests {
         let mut store = make_store();
         let receiver = store.add_listener(2);
 
-        store.log.append(67, Payload(Vec::new()));
-        store.log.append(67, Payload(Vec::new()));
-        store.log.append(68, Payload(Vec::new()));
+        store.append(67, Payload(Vec::new()));
+        store.append(67, Payload(Vec::new()));
+        store.append(68, Payload(Vec::new()));
 
         store.commit_to(2).await;
         let output = receiver.now_or_never();
@@ -335,7 +335,7 @@ mod tests {
         let receiver2 = store.add_listener(1);
         let receiver3 = store.add_listener(0);
 
-        store.log.append(67, Payload(Vec::new()));
+        store.append(67, Payload(Vec::new()));
         store.commit_to(0).await;
 
         assert!(receiver1.now_or_never().is_some());
@@ -347,8 +347,8 @@ mod tests {
     async fn test_listener_past() {
         let mut store = make_store();
 
-        store.log.append(67, Payload(Vec::new()));
-        store.log.append(67, Payload(Vec::new()));
+        store.append(67, Payload(Vec::new()));
+        store.append(67, Payload(Vec::new()));
         store.commit_to(1).await;
 
         let receiver = store.add_listener(0);
@@ -358,7 +358,7 @@ mod tests {
     #[tokio::test]
     async fn test_compaction() {
         let mut store = make_store();
-        let eid = store.log.append(
+        let eid = store.append(
             67,
             Payload(vec![0; 2 * COMPACTION_THRESHOLD_BYTES as usize]),
         );

--- a/src/raft/store.rs
+++ b/src/raft/store.rs
@@ -1,6 +1,6 @@
 use crate::raft::log::{ContainsResult, LogSlice};
 use crate::raft::raft_proto::entry::Data;
-use crate::raft::raft_proto::EntryId;
+use crate::raft::raft_proto::{Entry, EntryId};
 use crate::raft::StateMachine;
 use async_std::sync::{Arc, Mutex};
 use bytes::Bytes;
@@ -29,6 +29,16 @@ pub struct Store {
 
     compaction_threshold_bytes: i64,
     name: String,
+}
+
+// Holds information about config struts in the store.
+#[derive(Clone, Debug, PartialEq)]
+pub struct ConfigInfo {
+    // The latest appended entry containing a cluster config.
+    pub latest: Option<Entry>,
+
+    // Whether or not the latest entry has been committed.
+    pub committed: bool,
 }
 
 impl Store {
@@ -65,6 +75,12 @@ impl Store {
     // the id for the created entry.
     pub fn append(&mut self, term: i64, data: Data) -> EntryId {
         self.log.append(term, data)
+    }
+
+    // Returns information about cluster config entries in the store.
+    pub fn get_config_info(&self) -> ConfigInfo {
+        // TODO(dino): implement
+        unimplemented!();
     }
 
     // Compacts logs entries into a new snapshot if necessary.

--- a/src/raft/store.rs
+++ b/src/raft/store.rs
@@ -173,7 +173,7 @@ impl Store {
             self.applied = self.applied + 1;
             let entry = self.log.entry_at(self.applied);
             let entry_id = entry.id.expect("id").clone();
-            
+
             if let Some(Data::Payload(bytes)) = entry.data {
                 let result = self.state_machine.lock().await.apply(&Bytes::from(bytes));
                 match result {

--- a/src/raft/store.rs
+++ b/src/raft/store.rs
@@ -86,6 +86,11 @@ impl Store {
         self.snapshot.clone()
     }
 
+    // Returns the index of the first entry not (yet) present in the store.
+    pub fn next_index(&self) -> i64 {
+        self.log.next_index()
+    }
+
     // Applies the supplied data to the log (without necessarily committing it). Returns
     // the id for the created entry.
     pub fn append(&mut self, term: i64, data: Data) -> EntryId {
@@ -359,6 +364,7 @@ mod tests {
         assert_eq!(store.committed_index(), -1);
         assert_eq!(store.applied, -1);
         assert!(store.get_latest_snapshot().is_none());
+        assert_eq!(store.next_index(), 0);
     }
 
     #[tokio::test]


### PR DESCRIPTION
The main necessary changes to make this happen:

* Introduce a new kind of payload to the Raft log entry, holding configs
* Teach the cluster module to deal with the possibility of cluster members changing
* Add a new rpc to the Raft service to support changing cluster configurations
* Teaching Raft cluster members to support the case of not being part of the cluster
* Implement the notion of "joint consensus" and the two-phase config shift as described in the Raft paper