### PR TITLE
Fix a bug where cancelled follower timeouts were still happening

### DIFF
--- a/src/raft/cluster.rs
+++ b/src/raft/cluster.rs
@@ -1,6 +1,7 @@
 use crate::raft::raft_proto::raft_client::RaftClient;
 use crate::raft::raft_proto::Server;
 use std::collections::HashMap;
+use std::time::Duration;
 use tonic::transport::{Channel, Endpoint, Error};
 
 // Holds information about a Raft cluster.
@@ -68,7 +69,13 @@ impl Cluster {
 
         // Cache miss, create a new channel.
         let dst = format!("http://[::1]:{}", address.port);
-        let channel = Endpoint::new(dst)?.connect().await?;
+        let timeout = Duration::from_secs(1);
+        let channel = Endpoint::new(dst)?
+            .connect_timeout(timeout.clone())
+            .timeout(timeout.clone())
+            .connect()
+            .await?;
+
         self.channels.insert(k, channel.clone());
         Ok(RaftClient::new(channel))
     }


### PR DESCRIPTION
The bug occurred because we had two layers of task::spawn() calls in the follower timeout logic. This in turn led to cancellation only affecting the outer layer, and not actually cancelling the control flow.

The overall effect was a lot of thrash in leader election because even with an established leader, runaway follower timeout code would start new elections.

This change also does a few minor cleanups:
* Replace some static functions with member functions
* Add timeouts to connect calls
* Reuse follower timeout scheduling logic rather than duplicating it
* Shorten timeouts by default