### PR TITLE
Disentangle the kv service from the raft state machine and make the store reusable

### DIFF
--- a/src/keyvalue/mod.rs
+++ b/src/keyvalue/mod.rs
@@ -2,6 +2,7 @@
 // cluster. Users of this module are expected to run the service in their grpc
 // server and/or use the generated grpc client code to make requests.
 
+pub use crate::keyvalue::store::{MapStore, Store};
 pub use service::KeyValueService;
 
 pub mod grpc {


### PR DESCRIPTION
This is in preparation for exposing an HTTP debug service using the same store.