### PR TITLE
Tone down log chattiness and make failure injection configurable

### DIFF
--- a/src/raft/failure_injection.rs
+++ b/src/raft/failure_injection.rs
@@ -19,6 +19,7 @@ use tower::BoxError;
 use tracing::debug;
 
 // Options used to control RPC failure injection.
+#[derive(Debug, Clone)]
 pub struct FailureOptions {
     // Probability with which intercepted RPCs should succeed.
     pub failure_probability: f64,
@@ -32,7 +33,6 @@ pub struct FailureOptions {
 
 impl FailureOptions {
     // Returns failure injection options which don't add any failures.
-    #[cfg(test)]
     pub const fn no_failures() -> Self {
         Self {
             failure_probability: 0.0,

--- a/src/raft/mod.rs
+++ b/src/raft/mod.rs
@@ -11,6 +11,7 @@
 pub use client::{new_client, Client};
 pub use consensus::{Options, RaftImpl};
 pub use diagnostics::Diagnostics;
+pub use failure_injection::FailureOptions;
 pub use state_machine::{StateMachine, StateMachineResult};
 
 #[path = "generated/raft_proto.rs"]


### PR DESCRIPTION
New sample output:

```
2023-04-02T17:45:11.637140Z  INFO Starting 5 servers
2023-04-02T17:45:11.637848Z  INFO serve{server=12345}: Created raft and key-value service
2023-04-02T17:45:11.638521Z  INFO serve{server=12346}: Created raft and key-value service
2023-04-02T17:45:11.638747Z  INFO serve{server=12347}: Created raft and key-value service
2023-04-02T17:45:11.638962Z  INFO serve{server=12348}: Created raft and key-value service
2023-04-02T17:45:11.639168Z  INFO serve{server=12349}: Created raft and key-value service
2023-04-02T17:45:13.273863Z  INFO put: success i=1 latency_ms=15
2023-04-02T17:45:15.951287Z  INFO preempt: success leader=12346 latency_ms=309
2023-04-02T17:45:23.682608Z  INFO put: success i=11 latency_ms=6
2023-04-02T17:45:26.955551Z  INFO reconfigure: success latency_ms=314 new_members=["12345", "12348", "12347"]
2023-04-02T17:45:30.267104Z  INFO preempt: success leader=12347 latency_ms=310
2023-04-02T17:45:34.179651Z  INFO put: success i=21 latency_ms=6
```