### PR TITLE
Add a serving multiplexer to serve both web and grpc requests on the same port

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -278,9 +278,9 @@ dependencies = [
  "bitflags 1.3.2",
  "bytes",
  "futures-util",
- "http",
- "http-body",
- "hyper",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.28",
  "itoa",
  "matchit",
  "memchr",
@@ -289,7 +289,11 @@ dependencies = [
  "pin-project-lite",
  "rustversion",
  "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
  "sync_wrapper",
+ "tokio",
  "tower",
  "tower-layer",
  "tower-service",
@@ -304,8 +308,8 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http",
- "http-body",
+ "http 0.2.12",
+ "http-body 0.4.6",
  "mime",
  "rustversion",
  "tower-layer",
@@ -332,6 +336,12 @@ name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
@@ -429,13 +439,18 @@ version = "0.1.0"
 dependencies = [
  "async-std",
  "async-trait",
+ "axum",
  "bytes",
  "chrono",
  "futures",
+ "hyper 0.14.28",
  "im",
+ "multiplex-tonic-hyper",
  "pin-project",
  "prost",
+ "querystring",
  "rand",
+ "reqwest",
  "structopt",
  "timer",
  "tokio",
@@ -457,6 +472,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -473,6 +498,15 @@ name = "either"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a47c1c47d2f5964e29c61246e81db715514cd532db6b5116a25ea3c03d6780a2"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b45de904aa0b010bce2ab45264d0631681847fa7b6f2eaa7dab7619943bc4f59"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "equivalent"
@@ -564,6 +598,30 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
+dependencies = [
+ "percent-encoding",
+]
 
 [[package]]
 name = "futures"
@@ -722,7 +780,26 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http",
+ "http 0.2.12",
+ "indexmap 2.2.6",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa82e28a107a8cc405f0839610bdc9b15f1e25ec7d696aa5cf173edbcb1486ab"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http 1.1.0",
  "indexmap 2.2.6",
  "slab",
  "tokio",
@@ -784,13 +861,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
 name = "http-body"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
 dependencies = [
  "bytes",
- "http",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cac85db508abc24a2e48553ba12a996e87244a0395ce011e62b37158745d643"
+dependencies = [
+ "bytes",
+ "http 1.1.0",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0475f8b2ac86659c21b64320d5d653f9efe42acd2a4e560073ec61a155a34f1d"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http 1.1.0",
+ "http-body 1.0.0",
  "pin-project-lite",
 ]
 
@@ -816,9 +927,9 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
- "http",
- "http-body",
+ "h2 0.3.26",
+ "http 0.2.12",
+ "http-body 0.4.6",
  "httparse",
  "httpdate",
  "itoa",
@@ -831,15 +942,71 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe575dd17d0862a9a33781c8c4696a55c320909004a67a00fb286ba8b1bc496d"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "h2 0.4.5",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
 name = "hyper-timeout"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
 dependencies = [
- "hyper",
+ "hyper 0.14.28",
  "pin-project-lite",
  "tokio",
  "tokio-io-timeout",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper 1.3.1",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d8d52be92d09acc2e01dddb7fde3ad983fc6489c7db4837e605bc3fca4cb63e"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "hyper 1.3.1",
+ "pin-project-lite",
+ "socket2 0.5.6",
+ "tokio",
+ "tower",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -863,6 +1030,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "idna"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
 ]
 
 [[package]]
@@ -918,6 +1095,12 @@ dependencies = [
  "libc",
  "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "ipnet"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
 
 [[package]]
 name = "itertools"
@@ -1039,6 +1222,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
 
 [[package]]
+name = "multiplex-tonic-hyper"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "002f157801c0a446aac0949ca2ff38508e9b5ed9e10c98260eb031677b3c82fc"
+dependencies = [
+ "futures",
+ "hyper 0.14.28",
+ "pin-project",
+ "tower",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1081,6 +1294,50 @@ name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+
+[[package]]
+name = "openssl"
+version = "0.10.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95a0481286a310808298130d22dd1fef0fa571e05a8f44ec801801e84b216b1f"
+dependencies = [
+ "bitflags 2.5.0",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.60",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c597637d56fbc83893a35eb0dd04b2b8e7a50c91e64e9493e398b5df4fb45fa2"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "overload"
@@ -1152,6 +1409,12 @@ dependencies = [
  "fastrand 2.0.2",
  "futures-io",
 ]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
 name = "polling"
@@ -1287,6 +1550,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "querystring"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9318ead08c799aad12a55a3e78b82e0b6167271ffd1f627b758891282f739187"
+
+[[package]]
 name = "quote"
 version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1379,6 +1648,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
 
 [[package]]
+name = "reqwest"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "566cafdd92868e0939d3fb961bd0dc25fcfaaed179291093b3d43e6b3150ea10"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2 0.4.5",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "http-body-util",
+ "hyper 1.3.1",
+ "hyper-tls",
+ "hyper-util",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls-pemfile",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "system-configuration",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "winreg",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1412,10 +1723,64 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-pemfile"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29993a25686778eb88d4189742cd713c9bce943bc54251a33509dc63cbacf73d"
+dependencies = [
+ "base64 0.22.1",
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "976295e77ce332211c0d24d92c0e83e50f5c5f046d11082cea19f3df13a3562d"
+
+[[package]]
 name = "rustversion"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80af6f9131f277a45a3fba6ce8e2258037bb0477a67e610d3c1fe046ab31de47"
+
+[[package]]
+name = "ryu"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
+
+[[package]]
+name = "schannel"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbc91545643bcf3a0bbb6569265615222618bdf33ce4ffbbd13c4bbd4c093534"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c627723fd09706bacdb5cf41499e95098555af3c3c29d014dc3c458ef6be11c0"
+dependencies = [
+ "bitflags 2.5.0",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "317936bbbd05227752583946b9e66d7ce3b489f84e11a94a510b4437fef407d7"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "serde"
@@ -1435,6 +1800,39 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.60",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.116"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e17db7126d17feb94eb3fad46bf1a96b034e8aacbc2e775fe81505f8b0b2813"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af99884400da37c88f5e9146b7f1fd0fbcae8f6eec4e9da38b67d05486f814a6"
+dependencies = [
+ "itoa",
+ "serde",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -1550,6 +1948,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
+name = "system-configuration"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1590,6 +2009,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1628,6 +2062,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-stream"
 version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1661,12 +2105,12 @@ dependencies = [
  "async-stream",
  "async-trait",
  "axum",
- "base64",
+ "base64 0.21.7",
  "bytes",
- "h2",
- "http",
- "http-body",
- "hyper",
+ "h2 0.3.26",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.28",
  "hyper-timeout",
  "percent-encoding",
  "pin-project",
@@ -1799,10 +2243,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "unicode-segmentation"
@@ -1817,6 +2276,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
 
 [[package]]
+name = "url"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+]
+
+[[package]]
 name = "valuable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1827,6 +2297,12 @@ name = "value-bag"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74797339c3b98616c009c7c3eb53a0ce41e85c8ec66bd3db96ed132d20cfdee8"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vec_map"
@@ -2106,3 +2582,13 @@ name = "windows_x86_64_msvc"
 version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
+
+[[package]]
+name = "winreg"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,12 +7,16 @@ edition = "2021"
 [dependencies]
 async-std = {version = "1.12", features = ["attributes"]}
 async-trait = "0.1.80"
+axum = "0.6.12"
 bytes = "1.6"
 chrono = "0.4"
 futures = "0.3"
+hyper="0.14.25"
+multiplex-tonic-hyper = "0.1"
 im = "15"
 prost = "0.12"
 rand = "0.8"
+reqwest = "0.12"
 structopt = "0.3"
 timer = "0.2"
 tokio = { version = "1.37", features = ["macros", "rt-multi-thread"] }
@@ -22,6 +26,7 @@ tracing = "0.1.40"
 tracing-subscriber = {version = "0.3.1", features = ["env-filter"]}
 tower = "0.4.13"
 pin-project = "1.1"
+querystring = "1.1"
 
 [build-dependencies]
 tonic-build = "0.11"

--- a/src/keyvalue/http.rs
+++ b/src/keyvalue/http.rs
@@ -1,0 +1,172 @@
+use axum::routing::get;
+use axum::Router;
+use hyper::{Body, StatusCode};
+use std::sync::Arc;
+use tonic::Request;
+
+use crate::keyvalue::keyvalue_proto::key_value_server::KeyValue;
+use crate::keyvalue::keyvalue_proto::GetRequest;
+
+// Provides an HTTP interface for the supplied KeyValue instance.
+#[derive(Clone)]
+pub struct HttpHandler {
+    service: Arc<dyn KeyValue>,
+}
+
+impl HttpHandler {
+    pub fn new(service: Arc<dyn KeyValue>) -> Self {
+        Self { service }
+    }
+
+    /**
+     * Installs routes that allow interacting with the keyvalue store. Example queries
+     * include /get?key=foo.
+     */
+    pub fn routes(self: Arc<Self>) -> Router {
+        let hello = move |req: hyper::Request<Body>| async move { self.handle_get(req).await };
+        Router::new().route("/get", get(hello))
+    }
+
+    fn make_response(code: StatusCode, message: String) -> hyper::Response<Body> {
+        hyper::Response::builder()
+            .status(code)
+            .body(Body::from(format!("{}\n", message)))
+            .unwrap()
+    }
+
+    fn invalid(message: String) -> hyper::Response<Body> {
+        Self::make_response(StatusCode::BAD_REQUEST, message)
+    }
+
+    async fn handle_get(&self, request: hyper::Request<Body>) -> hyper::Response<Body> {
+        let query = match request.uri().query() {
+            Some(q) => q,
+            None => return HttpHandler::invalid("must pass query".to_string()),
+        };
+
+        let parsed = querystring::querify(query);
+        let key = match parsed
+            .iter()
+            .find(|(a, _)| a.eq(&"key"))
+            .map(|(_, b)| b.to_string())
+        {
+            Some(value) => value,
+            _ => return HttpHandler::invalid("must pass key parameter".to_string()),
+        };
+
+        let request = Request::new(GetRequest {
+            key: key.clone().as_bytes().to_vec(),
+            version: -1,
+        });
+
+        match self.service.get(request).await {
+            Ok(p) => {
+                let proto = p.into_inner();
+                match proto.entry {
+                    Some(e) => match String::from_utf8(e.value) {
+                        Ok(value) => HttpHandler::make_response(
+                            StatusCode::OK,
+                            format!("{}={}, version={}", key, value, proto.version),
+                        ),
+                        _ => HttpHandler::make_response(
+                            StatusCode::BAD_REQUEST,
+                            format!("failed to parse value as utf8 for key {}", key),
+                        ),
+                    },
+                    None => HttpHandler::make_response(
+                        StatusCode::NOT_FOUND,
+                        format!("no value for key {}", key),
+                    ),
+                }
+            }
+            Err(status) => HttpHandler::make_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Failed to query keyvalue store {}", status.to_string()),
+            ),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::keyvalue::grpc::PutRequest;
+    use crate::keyvalue::keyvalue_proto::{Entry, GetResponse, PutResponse};
+    use crate::testing::TestHttpServer;
+    use async_trait::async_trait;
+    use tonic::{Response, Status};
+
+    struct FakeKeyValue {}
+
+    #[async_trait]
+    impl KeyValue for FakeKeyValue {
+        async fn get(&self, request: Request<GetRequest>) -> Result<Response<GetResponse>, Status> {
+            let key = request.into_inner().key.clone();
+            let key_string = String::from_utf8(key.clone());
+            let entry = match key_string.expect("utf8").as_str() {
+                "foo" => Some(Entry {
+                    key: key.clone(),
+                    value: "foo-value".to_string().into_bytes(),
+                }),
+                "bar" => Some(Entry {
+                    key: key.clone(),
+                    value: "bar-value".to_string().into_bytes(),
+                }),
+                _ => None,
+            };
+
+            Ok(Response::new(GetResponse { entry, version: 0 }))
+        }
+
+        async fn put(&self, _: Request<PutRequest>) -> Result<Response<PutResponse>, Status> {
+            // We don't need any writes for now.
+            panic!("Not implemented");
+        }
+    }
+
+    async fn make_server() -> TestHttpServer {
+        let kv = Arc::new(FakeKeyValue {});
+        let http = Arc::new(HttpHandler {
+            service: kv.clone(),
+        });
+        let web_service = Router::new()
+            .nest("/keyvalue", http.routes())
+            .into_make_service();
+
+        TestHttpServer::run(web_service).await
+    }
+
+    async fn send_request(server: &TestHttpServer, path: &str) -> reqwest::Response {
+        let port = server.port().expect("port");
+        let uri = format!("http://{}:{}{}", "127.0.0.1", port, path);
+        reqwest::get(uri.as_str()).await.expect("request")
+    }
+
+    #[tokio::test]
+    async fn test_returns_value() {
+        let server = make_server().await;
+        let response = send_request(&server, "/keyvalue/get?key=foo").await;
+
+        let status = response.status().clone();
+        let text = response.text().await.expect("text");
+
+        assert_eq!(reqwest::StatusCode::OK, status);
+        assert_eq!("foo=foo-value, version=0", text.trim());
+    }
+
+    #[tokio::test]
+    async fn test_not_found() {
+        let server = make_server().await;
+        let response = send_request(&server, "/keyvalue/get?key=not-a-rea-key").await;
+        let status = response.status();
+        assert_eq!(reqwest::StatusCode::NOT_FOUND, status);
+    }
+
+    #[tokio::test]
+    async fn test_bad_path() {
+        let server = make_server().await;
+        let response = send_request(&server, "/INVALID/get?key=not-a-rea-key").await;
+        let status = response.status();
+        assert_eq!(reqwest::StatusCode::NOT_FOUND, status);
+    }
+}

--- a/src/keyvalue/mod.rs
+++ b/src/keyvalue/mod.rs
@@ -2,15 +2,17 @@
 // cluster. Users of this module are expected to run the service in their grpc
 // server and/or use the generated grpc client code to make requests.
 
-pub use crate::keyvalue::store::{MapStore};
+pub use crate::keyvalue::store::{MapStore, Store};
+pub use http::HttpHandler;
 pub use service::KeyValueService;
 
 pub mod grpc {
     pub use crate::keyvalue::keyvalue_proto::key_value_client::KeyValueClient;
     pub use crate::keyvalue::keyvalue_proto::key_value_server::KeyValueServer;
-    pub use crate::keyvalue::keyvalue_proto::{PutRequest};
+    pub use crate::keyvalue::keyvalue_proto::PutRequest;
 }
 
+pub(in crate::keyvalue) mod http;
 #[path = "generated/keyvalue_proto.rs"]
 pub(in crate::keyvalue) mod keyvalue_proto;
 pub(in crate::keyvalue) mod service;

--- a/src/keyvalue/store.rs
+++ b/src/keyvalue/store.rs
@@ -1,11 +1,11 @@
 extern crate bytes;
 extern crate im;
 
-use std::collections::VecDeque;
 use bytes::Bytes;
 use im::HashMap;
-use prost::Message;
 use keyvalue_proto::{Entry, Operation, Snapshot};
+use prost::Message;
+use std::collections::VecDeque;
 
 use crate::keyvalue::keyvalue_proto;
 use crate::keyvalue::keyvalue_proto::operation::Op::Set;

--- a/src/raft/consensus.rs
+++ b/src/raft/consensus.rs
@@ -1037,7 +1037,7 @@ mod tests {
     use crate::raft::raft_proto::raft_server::RaftServer;
     use crate::raft::testing::FakeStateMachine;
     use crate::raft_proto::Entry;
-    use crate::testing::TestServer;
+    use crate::testing::TestRpcServer;
 
     use super::*;
 
@@ -1056,7 +1056,7 @@ mod tests {
     async fn test_load_snapshot_and_append() {
         let raft = create_raft();
         let raft_state = raft.state.clone();
-        let server = TestServer::run(RaftServer::new(raft)).await;
+        let server = TestRpcServer::run(RaftServer::new(raft)).await;
 
         // Make an append request coming from a supposed leader, for a bunch of
         // entries far in the future.
@@ -1121,7 +1121,7 @@ mod tests {
     async fn test_append_and_compact() {
         let raft = create_raft();
         let raft_state = raft.state.clone();
-        let server = TestServer::run(RaftServer::new(raft)).await;
+        let server = TestRpcServer::run(RaftServer::new(raft)).await;
 
         // Make an append request coming from a leader, appending one record.
         let leader = create_fake_server_list()[1].clone();

--- a/src/testing/http_server.rs
+++ b/src/testing/http_server.rs
@@ -1,0 +1,67 @@
+extern crate tokio_stream;
+
+use axum::routing::IntoMakeService;
+use axum::Router;
+use tokio::sync::oneshot;
+use tokio::sync::oneshot::Sender;
+
+// A helper struct which can be used to test http handlers. Runs a real server
+// which binds to an arbitrary port and provides access to the resulting port.
+// Also takes care of tearing down the server when the instance goes out of
+// scope.
+pub struct TestHttpServer {
+    port: Option<u16>,
+    shutdown: Option<Sender<()>>,
+}
+
+impl TestHttpServer {
+    // One-stop-shop for running a single router on an arbitrary port. Returns
+    // the instance of TestHttpServer which provides access to the port. Panics if
+    // anything goes wrong during setup.
+    pub async fn run(router: IntoMakeService<Router>) -> Self {
+        let mut server = TestHttpServer {
+            port: None,
+            shutdown: None,
+        };
+        server.start(router).await;
+        server
+    }
+
+    // Returns the port the server is listening on.
+    pub fn port(&self) -> Option<u16> {
+        self.port
+    }
+
+    async fn start(&mut self, router: IntoMakeService<Router>) {
+        let (tx, rx) = oneshot::channel();
+        self.shutdown = Some(tx);
+
+        // Assign to an arbitrary free port
+        let addr = ([127, 0, 0, 1], 0).into();
+        let server_builder = hyper::Server::bind(&addr);
+        self.port = Some(server_builder.local_addr().port());
+
+        tokio::spawn(async {
+            let shutdown = async {
+                rx.await.ok();
+            };
+            server_builder
+                .serve(router)
+                .with_graceful_shutdown(shutdown)
+                .await
+                .expect("server");
+        });
+    }
+
+    fn stop(&mut self) {
+        if self.shutdown.is_some() {
+            self.shutdown.take().unwrap().send(()).expect("shutdown");
+        }
+    }
+}
+
+impl Drop for TestHttpServer {
+    fn drop(&mut self) {
+        self.stop();
+    }
+}

--- a/src/testing/mod.rs
+++ b/src/testing/mod.rs
@@ -1,5 +1,8 @@
 #[cfg(test)]
-pub use server::TestServer;
-
+pub use http_server::TestHttpServer;
 #[cfg(test)]
-mod server;
+pub use rpc_server::TestRpcServer;
+#[cfg(test)]
+mod http_server;
+#[cfg(test)]
+mod rpc_server;

--- a/src/testing/rpc_server.rs
+++ b/src/testing/rpc_server.rs
@@ -8,21 +8,21 @@ use tokio_stream::wrappers::TcpListenerStream;
 use tonic::body::BoxBody;
 use tonic::codegen::http::{Request, Response};
 use tonic::codegen::Service;
-use tonic::transport::Body;
 use tonic::server::NamedService;
+use tonic::transport::Body;
 
 // A helper struct which can be used to test grpc services. Runs a real server
 // which binds to an arbitrary port and provides access to the resulting port.
 // Also takes care of tearing down the server when the instance goes out of
 // scope.
-pub struct TestServer {
+pub struct TestRpcServer {
     port: Option<u16>,
     shutdown: Option<Sender<()>>,
 }
 
-impl TestServer {
+impl TestRpcServer {
     // One-stop-shop for running a single service on an arbitrary port. Returns
-    // the instance of TestService which provides access to the port. Panics if
+    // the instance of TestRpcServer which provides access to the port. Panics if
     // anything goes wrong during setup.
     pub async fn run<S>(service: S) -> Self
     where
@@ -34,7 +34,7 @@ impl TestServer {
         S::Future: Send + 'static,
         S::Error: std::error::Error + Send + Sync,
     {
-        let mut server = TestServer {
+        let mut server = TestRpcServer {
             port: None,
             shutdown: None,
         };
@@ -86,7 +86,7 @@ impl TestServer {
     }
 }
 
-impl Drop for TestServer {
+impl Drop for TestRpcServer {
     fn drop(&mut self) {
         self.stop();
     }


### PR DESCRIPTION
This PR adds an HTTP serving layer to the service started on each port. The (very basic) serving knows how to return the value and version associated with a key, as seen by the KeyValue store on the corresponding server.

Example URL to query for after running the main binary: `http://localhost:12345/keyvalue/get?key=foo`