### PR TITLE
Add diagnostics for applied commits

### DIFF
--- a/src/raft/consensus.rs
+++ b/src/raft/consensus.rs
@@ -104,6 +104,7 @@ impl RaftImpl {
         let store = Store::new(
             state_machine,
             snapshot,
+            diagnostics.clone(),
             options.compaction_threshold_bytes,
             server.name.as_str(),
         );


### PR DESCRIPTION
In this change we add a mechanism for the `Diagnostics` object to verify that applied commits have the same digest across all cluster participants.