### PR TITLE
Fix issue where leader tries to install snapshot before having a snapshot

### DIFF
--- a/src/keyvalue/mod.rs
+++ b/src/keyvalue/mod.rs
@@ -2,7 +2,7 @@
 // cluster. Users of this module are expected to run the service in their grpc
 // server and/or use the generated grpc client code to make requests.
 
-pub use crate::keyvalue::store::{MapStore, Store};
+pub use crate::keyvalue::store::MapStore;
 pub use http::HttpHandler;
 pub use service::KeyValueService;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -90,7 +90,9 @@ async fn run_server(address: &Server, all: &Vec<Server>, diagnostics: Arc<Mutex<
         Some(server_diagnostics),
         Options::default(),
         Some(DEFAULT_FAILURE_OPTIONS),
-    );
+    )
+    .await;
+
     raft.start().await;
     let raft_grpc = RaftServer::new(raft);
 


### PR DESCRIPTION
We fix the issue by making snapshots non-optional in the `Store` implementation.

Sample error observed in the wild:

```
2025-05-06T13:49:18.813196Z  INFO Starting 5 servers
2025-05-06T13:49:18.813752Z  INFO serve{server=12345}: Started server (http, grpc) on port 12345
2025-05-06T13:49:18.813800Z  INFO serve{server=12346}: Started server (http, grpc) on port 12346
2025-05-06T13:49:18.813828Z  INFO serve{server=12347}: Started server (http, grpc) on port 12347
2025-05-06T13:49:18.813855Z  INFO serve{server=12348}: Started server (http, grpc) on port 12348
2025-05-06T13:49:18.813884Z  INFO serve{server=12349}: Started server (http, grpc) on port 12349
2025-05-06T13:49:20.071076Z  INFO put: success i=1 latency_ms=2
2025-05-06T13:49:22.818385Z  INFO preempt: success leader=12345 latency_ms=2
2025-05-06T13:49:30.136056Z  INFO put: success i=11 latency_ms=1
2025-05-06T13:49:33.860388Z  INFO reconfigure: success latency_ms=44 new_members=["12345", "12346", "12347"]
2025-05-06T13:49:36.830872Z  INFO preempt: success leader=12346 latency_ms=9
2025-05-06T13:49:40.195710Z  INFO put: success i=21 latency_ms=2
2025-05-06T13:49:48.865533Z  INFO reconfigure: success latency_ms=3 new_members=["12345", "12349", "12347"]

thread 'tokio-runtime-worker' panicked at src/raft/consensus.rs:411:79:
last
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
2025-05-06T13:49:50.345786Z  INFO put: success i=31 latency_ms=2
2025-05-06T13:49:50.854444Z  INFO preempt: success leader=12347 latency_ms=21
```