### PR TITLE
Refactor raft state to isolate the persistent parts

### DIFF
--- a/src/keyvalue/http.rs
+++ b/src/keyvalue/http.rs
@@ -1,10 +1,10 @@
-use axum::routing::get;
 use axum::Router;
+use axum::routing::get;
 use std::sync::Arc;
 use tonic::Request;
 
-use crate::keyvalue::keyvalue_proto::key_value_server::KeyValue;
 use crate::keyvalue::keyvalue_proto::GetRequest;
+use crate::keyvalue::keyvalue_proto::key_value_server::KeyValue;
 use axum::body::Body;
 use axum::http::Request as HttpRequest;
 use axum::http::StatusCode;

--- a/src/keyvalue/mod.rs
+++ b/src/keyvalue/mod.rs
@@ -7,9 +7,9 @@ pub use http::HttpHandler;
 pub use service::KeyValueService;
 
 pub mod grpc {
+    pub use crate::keyvalue::keyvalue_proto::PutRequest;
     pub use crate::keyvalue::keyvalue_proto::key_value_client::KeyValueClient;
     pub use crate::keyvalue::keyvalue_proto::key_value_server::KeyValueServer;
-    pub use crate::keyvalue::keyvalue_proto::PutRequest;
 }
 
 pub(in crate::keyvalue) mod http;

--- a/src/keyvalue/service.rs
+++ b/src/keyvalue/service.rs
@@ -13,7 +13,7 @@ use crate::keyvalue::keyvalue_proto::{
 };
 use crate::keyvalue::store::Store;
 use crate::raft::raft_proto::Server;
-use crate::raft::{new_client, Client};
+use crate::raft::{Client, new_client};
 
 pub struct KeyValueService {
     // A name for this service, used for debugging, log messages, etc.
@@ -140,8 +140,8 @@ mod tests {
     use crate::keyvalue::keyvalue_proto::key_value_client::KeyValueClient;
     use crate::keyvalue::keyvalue_proto::key_value_server::KeyValueServer;
     use crate::keyvalue::store::MapStore;
-    use crate::raft::raft_proto::EntryId;
     use crate::raft::StateMachine;
+    use crate::raft::raft_proto::EntryId;
     use crate::testing::TestRpcServer;
 
     use super::*;

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,16 +5,16 @@ use async_std::sync::{Arc, Mutex};
 use axum::routing::Router;
 use axum_tonic::NestTonic;
 use axum_tonic::RestGrpcService;
-use futures::future::join5;
 use futures::future::join_all;
+use futures::future::join5;
 use rand::seq::SliceRandom;
 use std::error::Error;
 use std::net::SocketAddr;
 use std::time::Duration;
 use structopt::StructOpt;
 use tokio::net::TcpListener;
-use tokio::time::{sleep, Instant};
-use tracing::{debug, error, info, info_span, Instrument};
+use tokio::time::{Instant, sleep};
+use tracing::{Instrument, debug, error, info, info_span};
 use tracing_subscriber::EnvFilter;
 
 use crate::keyvalue::grpc::KeyValueClient;
@@ -23,8 +23,8 @@ use crate::keyvalue::grpc::PutRequest;
 use crate::keyvalue::{KeyValueService, MapStore};
 use crate::raft::raft_proto;
 use crate::raft::{Diagnostics, FailureOptions, Options, RaftImpl};
-use crate::raft_proto::raft_server::RaftServer;
 use crate::raft_proto::Server;
+use crate::raft_proto::raft_server::RaftServer;
 
 mod keyvalue;
 mod raft;
@@ -105,7 +105,9 @@ async fn run_server(address: &Server, all: &Vec<Server>, diagnostics: Arc<Mutex<
     let grpc = Router::new().nest_tonic(raft_grpc).nest_tonic(kv_grpc);
 
     let rest_grpc = RestGrpcService::new(web, grpc).into_make_service();
-    let listener = TcpListener::bind(&make_address(&address)).await.expect("bind");
+    let listener = TcpListener::bind(&make_address(&address))
+        .await
+        .expect("bind");
 
     info!("Started server (http, grpc) on port {}", address.port);
 

--- a/src/raft/client.rs
+++ b/src/raft/client.rs
@@ -4,8 +4,8 @@ use async_std::sync::Mutex;
 use async_trait::async_trait;
 use futures::Future;
 use tokio::time::sleep;
-use tonic::transport::{Channel, Error};
 use tonic::Request;
+use tonic::transport::{Channel, Error};
 use tracing::debug;
 
 use raft_proto::{CommitRequest, EntryId, Server, Status, StepDownRequest};

--- a/src/raft/consensus.rs
+++ b/src/raft/consensus.rs
@@ -8,25 +8,25 @@ use std::time::Duration;
 
 use async_std::sync::{Arc, Mutex};
 use bytes::Bytes;
-use futures::future::{err, join_all};
 use futures::FutureExt;
+use futures::future::{err, join_all};
 use rand::Rng;
 use tokio::task::JoinHandle;
 use tokio::time::sleep;
 use tonic::{Request, Response, Status};
-use tracing::{debug, info, info_span, instrument, warn, Instrument};
+use tracing::{Instrument, debug, info, info_span, instrument, warn};
 
 use diagnostics::ServerDiagnostics;
+use raft::StateMachine;
 use raft::log::ContainsResult;
 use raft::raft_proto;
-use raft::StateMachine;
 use raft_proto::{AppendRequest, AppendResponse, EntryId, Server, VoteRequest, VoteResponse};
 use raft_proto::{CommitRequest, CommitResponse, StepDownRequest, StepDownResponse};
 use raft_proto::{InstallSnapshotRequest, InstallSnapshotResponse};
 
 use crate::raft;
 use crate::raft::cluster::Cluster;
-use crate::raft::cluster::{key, RaftClientType};
+use crate::raft::cluster::{RaftClientType, key};
 use crate::raft::consensus::RaftRole::Leader;
 use crate::raft::diagnostics;
 use crate::raft::failure_injection::FailureOptions;
@@ -116,8 +116,6 @@ impl RaftImpl {
                 cluster,
                 diagnostics,
 
-                term: 0,
-                voted_for: None,
                 role: RaftRole::Follower,
                 followers: HashMap::new(),
                 timer_guard: None,
@@ -129,7 +127,7 @@ impl RaftImpl {
         let arc_state = self.state.clone();
 
         let mut state = self.state.lock().await;
-        let term = state.term;
+        let term = state.term();
         debug!(term, "starting");
         state.become_follower(arc_state.clone(), term);
 
@@ -190,7 +188,7 @@ impl RaftImpl {
             let mut state = arc_state.lock().await;
 
             // The world has moved on.
-            if state.term > term {
+            if state.term() > term {
                 return true;
             }
 
@@ -202,9 +200,9 @@ impl RaftImpl {
             // Prepare the election. Note that we don't reset the timer because this
             // would lead to cancelling our own ongoing execution.
             debug!(term, "starting election");
+            let me = state.cluster.me();
             state.role = RaftRole::Candidate;
-            state.term = term;
-            state.voted_for = Some(state.cluster.me());
+            state.store.update_term_info(term, &Some(me));
 
             // Request votes from all peers.
             let request = state.create_vote_request();
@@ -234,7 +232,7 @@ impl RaftImpl {
             let mut state = arc_state.lock().await;
 
             // The world has moved on or someone else has won in this term.
-            if state.term > term || state.role != RaftRole::Candidate {
+            if state.term() > term || state.role != RaftRole::Candidate {
                 return true;
             }
 
@@ -247,7 +245,7 @@ impl RaftImpl {
                 match response {
                     Ok((peer, message)) => {
                         if message.term > term {
-                            info!(term=state.term, other_term=message.term, role=?state.role, "detected higher term");
+                            info!(term=state.term(), other_term=message.term, role=?state.role, "detected higher term");
                             state.become_follower(arc_state.clone(), message.term);
                             return true;
                         }
@@ -291,17 +289,17 @@ impl RaftImpl {
             {
                 let arc_state_copy = arc_state.clone();
                 let mut state = arc_state.lock().await;
-                if state.term > term {
-                    debug!(term=state.term, role=?state.role, "detected higher term");
+                if state.term() > term {
+                    debug!(term=state.term(), role=?state.role, "detected higher term");
                     return;
                 }
                 if state.role != RaftRole::Leader {
-                    debug!(term=state.term, role=?state.role, "no longer leader");
+                    debug!(term=state.term(), role=?state.role, "no longer leader");
                     return;
                 }
                 if !state.cluster.am_voting_member() {
                     info!("no longer voting member, stepping down");
-                    let t = state.term;
+                    let t = state.term();
                     state.become_follower(arc_state_copy, t);
                     return;
                 }
@@ -329,8 +327,8 @@ impl RaftImpl {
         {
             let mut state = arc_state.lock().await;
             debug!("replicating entries");
-            if state.term > term {
-                debug!(term=state.term, role=?state.role, "detected higher term");
+            if state.term() > term {
+                debug!(term=state.term(), role=?state.role, "detected higher term");
                 return;
             }
 
@@ -355,7 +353,7 @@ impl RaftImpl {
                 }
 
                 let client = client.unwrap();
-                if state.store.log.is_index_compacted(next_index) {
+                if state.store.is_index_compacted(next_index) {
                     let request = state.create_snapshot_request();
                     let fut = RaftImpl::replicate_snapshot(
                         client,
@@ -383,12 +381,12 @@ impl RaftImpl {
         {
             let arc_state_copy = arc_state.clone();
             let mut state = arc_state.lock().await;
-            if state.term > term {
-                debug!(term=state.term, role=?state.role, "detected higher term");
+            if state.term() > term {
+                debug!(term=state.term(), role=?state.role, "detected higher term");
                 return;
             }
             if state.role != RaftRole::Leader {
-                debug!(term=state.term, role=?state.role, "no longer leader");
+                debug!(term=state.term(), role=?state.role, "no longer leader");
                 return;
             }
             state.update_committed(arc_state_copy).await;
@@ -413,7 +411,7 @@ impl RaftImpl {
             Ok(result) => {
                 let response = result.into_inner();
                 let other_term = response.term;
-                if other_term > state.term {
+                if other_term > state.term() {
                     info!(other_term, peer=%follower.name, role=?state.role, "detected higher term");
                     state.become_follower(arc_state.clone(), other_term);
                     return;
@@ -437,12 +435,12 @@ impl RaftImpl {
         let result = client.append(request).await;
 
         let mut state = arc_state.lock().await;
-        if state.term > append_request.term {
-            debug!(term=state.term, role=?state.role, "detected higher term");
+        if state.term() > append_request.term {
+            debug!(term=state.term(), role=?state.role, "detected higher term");
             return;
         }
         if state.role != RaftRole::Leader {
-            debug!(term=state.term, role=?state.role, "no longer leader");
+            debug!(term=state.term(), role=?state.role, "no longer leader");
             return;
         }
 
@@ -451,8 +449,8 @@ impl RaftImpl {
             Ok(response) => {
                 let message = response.into_inner();
                 let other_term = message.term;
-                if other_term > state.term {
-                    debug!(other_term, term=state.term, role=?state.role, "detected higher term");
+                if other_term > state.term() {
+                    debug!(other_term, term=state.term(), role=?state.role, "detected higher term");
                     state.become_follower(arc_state.clone(), other_term);
                     return;
                 }
@@ -478,7 +476,7 @@ impl RaftImpl {
                 return Err(raft_proto::Status::NotLeader);
             }
 
-            term = state.term;
+            term = state.term();
             entry_id = state.store.append(term, data);
             receiver = state.store.add_listener(entry_id.index);
 
@@ -569,9 +567,7 @@ struct RaftState {
     store: Store,
     cluster: Cluster,
 
-    // Term state.
-    term: i64,
-    voted_for: Option<Server>,
+    // Volatile term state. The persistent term state is kept in "store"
     role: RaftRole,
     followers: HashMap<String, FollowerPosition>,
     timer_guard: Option<TimerGuard>,
@@ -584,6 +580,16 @@ struct RaftState {
 impl RaftState {
     fn name(&self) -> String {
         self.cluster.me().name.to_string()
+    }
+
+    // Returns the canonical record of the current term for this instance.
+    fn term(&self) -> i64 {
+        self.store.term()
+    }
+
+    // Returns which candidate this instance voted for in the current term, if any.
+    fn voted_for(&self) -> Option<Server> {
+        self.store.voted_for()
     }
 
     // Returns a suitable initial map of follower positions. Meant to be called
@@ -616,14 +622,14 @@ impl RaftState {
     // exist in our current log.
     fn create_append_request(&self, next_index: i64) -> AppendRequest {
         // This method should only get called if we know the index is present.
-        assert!(!self.store.log.is_index_compacted(next_index));
-        let previous = self.store.log.id_at(next_index - 1);
+        assert!(!self.store.is_index_compacted(next_index));
+        let previous = self.store.entry_id_at_index(next_index - 1);
 
         AppendRequest {
-            term: self.term,
+            term: self.term(),
             leader: Some(self.cluster.me()),
             previous: Some(previous.clone()),
-            entries: self.store.log.get_entries_after(&previous),
+            entries: self.store.get_entries_after(&previous),
             committed: self.store.committed_index(),
         }
     }
@@ -636,7 +642,7 @@ impl RaftState {
         let last = Some(snap.last.clone());
 
         InstallSnapshotRequest {
-            term: self.term,
+            term: self.term(),
             leader: Some(self.cluster.me()),
             snapshot: bytes,
             last,
@@ -645,18 +651,17 @@ impl RaftState {
 
     fn become_follower(&mut self, arc_state: Arc<Mutex<RaftState>>, term: i64) {
         debug!(term, "becoming follower");
-        assert!(term >= self.term, "Term should never decrease");
+        assert!(term >= self.term(), "Term should never decrease");
 
-        self.term = term;
+        self.store.update_term_info(term, &None /* voted_for */);
         self.role = RaftRole::Follower;
-        self.voted_for = None;
         self.reset_follower_timer(arc_state.clone(), term + 1);
     }
 
     fn reset_follower_timer(&mut self, arc_state: Arc<Mutex<RaftState>>, next_term: i64) {
         let timeout_ms = self.options.follower_timeout_ms;
         let me = self.name();
-        let term = self.term;
+        let term = self.term();
         let span = info_span!(parent: None, "election", server = %me);
         let task = sleep(Duration::from_millis(add_jitter(timeout_ms))).then(async move |_| {
             debug!(term, "follower timeout");
@@ -752,7 +757,7 @@ impl RaftState {
 
         if self.role == Leader && !self.cluster.am_voting_member() {
             debug!(role=?self.role, me=?self.cluster.me().name, "not voting member, stepping down");
-            let term = self.term;
+            let term = self.term();
             self.become_follower(arc_state, term);
         }
     }
@@ -761,9 +766,9 @@ impl RaftState {
     // of peer servers in an election.
     fn create_vote_request(&self) -> VoteRequest {
         VoteRequest {
-            term: self.term,
+            term: self.term(),
             candidate: Some(self.cluster.me()),
-            last: Some(self.store.log.last_known_id().clone()),
+            last: Some(self.store.last_known_log_entry_id().clone()),
         }
     }
 
@@ -790,9 +795,9 @@ impl Raft for RaftImpl {
         let mut state = self.state.lock().await;
 
         // Reject anything from an outdated term.
-        if state.term > request.term {
+        if state.term() > request.term {
             return Ok(Response::new(VoteResponse {
-                term: state.term,
+                term: state.term(),
                 granted: false,
             }));
         }
@@ -802,7 +807,7 @@ impl Raft for RaftImpl {
         if let Some(server) = request.candidate.clone() {
             if !state.cluster.is_voting_member(&server) {
                 return Ok(Response::new(VoteResponse {
-                    term: state.term,
+                    term: state.term(),
                     granted: false,
                 }));
             }
@@ -810,18 +815,22 @@ impl Raft for RaftImpl {
 
         // If we're in an outdated term, we revert to follower in the new later
         // term and may still grant the requesting candidate our vote.
-        if request.term > state.term {
+        if request.term > state.term() {
             state.become_follower(self.state.clone(), request.term);
         }
 
         let candidate = request.candidate;
+        candidate.clone().expect("Candidate is None");
 
         let granted;
-        let term = state.term;
-        if state.voted_for.is_none() || &candidate == &state.voted_for {
+        let term = state.term();
+        if state.voted_for().is_none() || &candidate == &state.voted_for() {
             let candidate_name = candidate.clone().map(|x| x.name);
-            if state.store.log.is_up_to_date(&request.last.expect("last")) {
-                state.voted_for = candidate.clone();
+            if state
+                .store
+                .log_entry_is_up_to_date(&request.last.expect("last"))
+            {
+                state.store.update_voted_for(&candidate.clone());
                 granted = true;
                 debug!(term, candidate=?candidate_name, "granted vote");
             } else {
@@ -829,12 +838,12 @@ impl Raft for RaftImpl {
                 granted = false;
             }
         } else {
-            debug!(term, voted_for = ?state.voted_for.clone().map(|x| x.name), "denied vote, already voted");
+            debug!(term, voted_for = ?state.voted_for().clone().map(|x| x.name), "denied vote, already voted");
             granted = false;
         }
 
         Ok(Response::new(VoteResponse {
-            term: state.term,
+            term: state.term(),
             granted,
         }))
     }
@@ -851,9 +860,9 @@ impl Raft for RaftImpl {
 
         // Handle the case where we are ahead of the leader. We inform the
         // leader of our (greater) term and fail the append.
-        if state.term > request.term {
+        if state.term() > request.term {
             return Ok(Response::new(AppendResponse {
-                term: state.term,
+                term: state.term(),
                 success: false,
                 next: state.store.next_index(),
             }));
@@ -862,7 +871,7 @@ impl Raft for RaftImpl {
         // If the leader's term is greater than ours, we update ours to match
         // by resetting to a "clean" follower state for the leader's (greater)
         // term. Note that we then handle the leader's append afterwards.
-        if request.term > state.term {
+        if request.term > state.term() {
             state.become_follower(self.state.clone(), request.term);
         }
 
@@ -870,12 +879,12 @@ impl Raft for RaftImpl {
         let leader = request.leader.expect("leader").clone();
         state.cluster.record_leader(&leader);
         match &state.diagnostics {
-            Some(d) => d.lock().await.report_leader(state.term, &leader),
+            Some(d) => d.lock().await.report_leader(state.term(), &leader),
             _ => (),
         }
 
         // Reset the election timer
-        let term = state.term;
+        let term = state.term();
         state.reset_follower_timer(self.state.clone(), term + 1);
 
         // Make sure we have the previous log index sent. Note that COMPACTED
@@ -883,7 +892,7 @@ impl Raft for RaftImpl {
         // a snapshot install).
         let previous = &request.previous.expect("previous");
         let next_index = state.store.next_index();
-        if state.store.log.contains(previous) == ContainsResult::ABSENT {
+        if state.store.log_contains(previous) == ContainsResult::ABSENT {
             // Let the leader know that this entry is too far in the future, so
             // it can try again from with earlier index.
             return Ok(Response::new(AppendResponse {
@@ -956,7 +965,7 @@ impl Raft for RaftImpl {
             }));
         }
 
-        let term = state.term;
+        let term = state.term();
         state.become_follower(self.state.clone(), term);
 
         Ok(Response::new(StepDownResponse {
@@ -974,7 +983,7 @@ impl Raft for RaftImpl {
         debug!(?request, "handling request");
 
         let mut state = self.state.lock().await;
-        if request.term >= state.term && !request.snapshot.is_empty() {
+        if request.term >= state.term() && !request.snapshot.is_empty() {
             let last = request.last.expect("last");
             let snapshot = Bytes::from(request.snapshot.to_vec());
             let status = state.store.install_snapshot(snapshot, last).await;
@@ -982,7 +991,9 @@ impl Raft for RaftImpl {
                 return Err(status);
             }
         }
-        Ok(Response::new(InstallSnapshotResponse { term: state.term }))
+        Ok(Response::new(InstallSnapshotResponse {
+            term: state.term(),
+        }))
     }
 
     #[instrument(fields(server=?self.address.name),skip(self,request))]
@@ -1051,7 +1062,7 @@ mod tests {
         let raft = create_raft().await;
         let state = raft.state.lock().await;
         assert_eq!(state.role, RaftRole::Follower);
-        assert_eq!(state.term, 0);
+        assert_eq!(state.term(), 0);
     }
 
     // This test verifies that initially, a follower fails to accept entries
@@ -1155,8 +1166,8 @@ mod tests {
         {
             let state = raft_state.lock().await;
             assert_eq!(state.cluster.leader(), Some(leader.clone()));
-            assert_eq!(state.term, 12);
-            assert!(!state.store.log.is_index_compacted(0)); // Not compacted
+            assert_eq!(state.term(), 12);
+            assert!(!state.store.is_index_compacted(0)); // Not compacted
             assert_eq!(state.store.next_index(), 3);
         }
 
@@ -1164,7 +1175,7 @@ mod tests {
         {
             let mut state = raft_state.lock().await;
             state.store.try_compact().await;
-            assert!(!state.store.log.is_index_compacted(0)); // Not compacted
+            assert!(!state.store.is_index_compacted(0)); // Not compacted
             assert_eq!(state.store.next_index(), 3);
         }
 
@@ -1195,7 +1206,7 @@ mod tests {
         assert!(append_response_2.success);
         {
             let state = raft_state.lock().await;
-            assert!(!state.store.log.is_index_compacted(0)); // Not compacted
+            assert!(!state.store.is_index_compacted(0)); // Not compacted
             assert_eq!(state.store.next_index(), 4); // New entry incorporated
         }
 
@@ -1203,7 +1214,7 @@ mod tests {
         {
             let mut state = raft_state.lock().await;
             state.store.try_compact().await;
-            assert!(state.store.log.is_index_compacted(0)); // Compacted
+            assert!(state.store.is_index_compacted(0)); // Compacted
             assert_eq!(state.store.get_latest_snapshot().last.index, 3)
         }
     }

--- a/src/raft/log.rs
+++ b/src/raft/log.rs
@@ -98,7 +98,7 @@ impl LogSlice {
         }
 
         // Terms are equal, last index decides.
-        return other_last.index >= this_last.index;
+        other_last.index >= this_last.index
     }
 
     // Returns true if the supplied entry is present in this slice.

--- a/src/raft/mod.rs
+++ b/src/raft/mod.rs
@@ -8,7 +8,7 @@
 // The implementation in this module is based on the paper at:
 // https://raft.github.io/raft.pdf
 
-pub use client::{new_client, Client};
+pub use client::{Client, new_client};
 pub use consensus::{Options, RaftImpl};
 pub use diagnostics::Diagnostics;
 pub use failure_injection::FailureOptions;

--- a/src/testing/http_server.rs
+++ b/src/testing/http_server.rs
@@ -1,7 +1,7 @@
 extern crate tokio_stream;
 
-use axum::routing::IntoMakeService;
 use axum::Router;
+use axum::routing::IntoMakeService;
 use std::net::SocketAddr;
 use tokio::net::TcpListener;
 use tokio::sync::oneshot;

--- a/src/testing/rpc_server.rs
+++ b/src/testing/rpc_server.rs
@@ -6,8 +6,8 @@ use tokio::sync::oneshot;
 use tokio::sync::oneshot::Sender;
 use tokio_stream::wrappers::TcpListenerStream;
 use tonic::body::BoxBody;
-use tonic::codegen::http::{Request, Response};
 use tonic::codegen::Service;
+use tonic::codegen::http::{Request, Response};
 use tonic::server::NamedService;
 
 // A helper struct which can be used to test grpc services. Runs a real server


### PR DESCRIPTION
In a follow-up PR we will actually write the persistent state to storage (e.g., disk). This change prepares by consolidating the canonical representations of the persistent state in one place.