### PR TITLE
Switch to async libraries in failure middleware

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -471,7 +471,6 @@ dependencies = [
  "rand",
  "reqwest",
  "structopt",
- "timer",
  "tokio",
  "tokio-stream",
  "tonic",
@@ -2091,15 +2090,6 @@ checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
 dependencies = [
  "cfg-if",
  "once_cell",
-]
-
-[[package]]
-name = "timer"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31d42176308937165701f50638db1c31586f183f1aab416268216577aec7306b"
-dependencies = [
- "chrono",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ prost = "0.13.5"
 rand = "0.8"
 reqwest = "0.12"
 structopt = "0.3"
-timer = "0.2"
 tokio = { version = "1.37", features = ["macros", "rt-multi-thread", "signal"] }
 tokio-stream = { version = "0.1", features = ["net"] }
 tonic = "0.12.3"


### PR DESCRIPTION
Improve and simplify the implementation of failure injection by using async libraries rather than blocking while polling futures.