### PR TITLE
Fix a bug where the client would keep bouncing between incorrect leaders and failing requests

### DIFF
--- a/src/raft/diagnostics.rs
+++ b/src/raft/diagnostics.rs
@@ -76,8 +76,8 @@ impl Diagnostics {
         self.servers.get(key.as_str()).unwrap().clone()
     }
 
-    // Returns the latest leader of a term that has been recognized as leader by all
-    // the participants. Returns None if there is no such term and leader.
+    // Returns the latest leader of a term that has been recognized as leader by some
+    // participant. Returns None if there is no such term and leader.
     pub fn latest_leader(&self) -> Option<(i64, Server)> {
         for (term, info) in self.leaders.iter().rev() {
             if let LeaderInfo::Leader(leader) = info {


### PR DESCRIPTION
Main fixes:
* Make sure we ask the cluster to record the correct leader, even on the leader node itself
* Don't hand out redirects to the last known leader if stale (e.g., self if no longer leader role, leader for stale term, etc)
* Distinguish the cases where commits fail due to internal errors vs. failure due to not leader