### PR TITLE
Add integration test for snapshotting and compaction

### DIFF
--- a/src/keyvalue/keyvalue_proto.proto
+++ b/src/keyvalue/keyvalue_proto.proto
@@ -53,17 +53,19 @@ message GetResponse {
   int64 version = 2;
 }
 
-// A request to set the value for a supplied key.
 message PutRequest {
-  // They key for which we are setting the value.
-  bytes key = 1;
-
-  // The value to write.
-  bytes value = 2;
+    bytes key = 1;
+    bytes value = 2;
 }
 
-// A response returned for a put request.
 message PutResponse {
+    // Debug information about the raft commit.
+    optional DebugInfo debug_info = 1;
+}
+
+// A request to set the value for a supplied key.
+message DebugInfo {
+    int64 raft_index = 1;
 }
 
 // An rpc service providing access to a key-value store.

--- a/src/raft/failure_injection.rs
+++ b/src/raft/failure_injection.rs
@@ -52,12 +52,12 @@ impl FailureOptions {
         }
     }
 
-    pub fn disconnect(&mut self, server: &Server) {
-        self.disconnected.insert(server.name.clone());
+    pub fn disconnect(&mut self, name: &str) {
+        self.disconnected.insert(name.to_string());
     }
 
-    pub fn reconnect(&mut self, server: &Server) {
-        self.disconnected.remove(&server.name);
+    pub fn reconnect(&mut self, name: &str) {
+        self.disconnected.remove(name);
     }
 }
 
@@ -400,7 +400,7 @@ mod tests {
             &self,
             _: tonic::Request<PutRequest>,
         ) -> Result<Response<PutResponse>, Status> {
-            Ok(Response::new(PutResponse {}))
+            Ok(Response::new(PutResponse { debug_info: None }))
         }
     }
 }

--- a/src/raft/mod.rs
+++ b/src/raft/mod.rs
@@ -11,6 +11,7 @@
 pub use client::{Client, new_client};
 pub use consensus::{Options, RaftImpl};
 pub use diagnostics::Diagnostics;
+pub use diagnostics::SnapshotInfo;
 pub use failure_injection::FailureOptions;
 pub use state_machine::{StateMachine, StateMachineResult};
 


### PR DESCRIPTION
Add support for collecting snapshot diagnostics and a few testing utilities to allow writing an integration test that verifies the snapshot installation flow.